### PR TITLE
Fix stale go-live preflight checks and portal download labels

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -123,7 +123,7 @@ init_db()
 # `python preflight.py` for the full report. Never prints secret values.
 try:
     from preflight import run_checks
-    _pf = run_checks()
+    _pf = run_checks(include_live_checks=False)
     log.info("Preflight: %s", _pf.summary_line())
     for _c in _pf.blockers:
         log.warning("Preflight BLOCKER — %s: %s", _c.name, _c.detail)

--- a/backend/preflight.py
+++ b/backend/preflight.py
@@ -159,7 +159,7 @@ def run_checks() -> Report:
             _stripe.api_key = sk
             endpoints = _stripe.WebhookEndpoint.list(limit=20)
             live_matches = [
-                e for e in endpoints.auto_paging_iter()
+                e for e in endpoints.data
                 if e.get("url", "").rstrip("/").endswith("/webhook/stripe")
                 and e.get("status") == "enabled"
             ]
@@ -222,12 +222,23 @@ def run_checks() -> Report:
                          "Accept": "application/vnd.github+json"},
                 timeout=10,
             )
-            if resp.status_code != 200:
+            if resp.status_code in (401, 403):
+                r.add("Installer binaries", BLOCKER,
+                      f"GitHub rejected GITHUB_RELEASES_TOKEN ({resp.status_code}) for {gh_repo} — "
+                      "every /download returns 503",
+                      "token is invalid, expired, or lacks Contents:read on that repo — "
+                      "regenerate a fine-grained PAT scoped to it")
+            elif resp.status_code == 404:
+                r.add("Installer binaries", BLOCKER,
+                      f"{gh_repo} or its latest release was not found (404) — "
+                      "every /download returns 503",
+                      "check GITHUB_RELEASES_REPO is correct and a release has been published, "
+                      "and that the token can see this repo (private repos need explicit access)")
+            elif resp.status_code != 200:
                 r.add("Installer binaries", BLOCKER,
                       f"GitHub releases lookup failed ({resp.status_code}) for {gh_repo} — "
                       "every /download returns 503",
-                      "check GITHUB_RELEASES_TOKEN has Contents:read on that repo, and that "
-                      "GITHUB_RELEASES_REPO is correct")
+                      "check GitHub's status and retry; if persistent, check GITHUB_RELEASES_REPO")
             else:
                 names = {a["name"] for a in resp.json().get("assets", [])}
                 present = [p for p, f in PLATFORM_FILES.items() if f in names]

--- a/backend/preflight.py
+++ b/backend/preflight.py
@@ -117,10 +117,24 @@ def run_checks() -> Report:
     elif sk.startswith("sk_test_"):
         r.add("STRIPE_SECRET_KEY", WARNING, "TEST key (sk_test_) — sandbox only, not real sales",
               "swap to sk_live_... before public launch")
-    elif sk.startswith("sk_live_"):
-        r.add("STRIPE_SECRET_KEY", OK, "live key present (sk_live_)")
-    elif sk.startswith("rk_live_"):
-        r.add("STRIPE_SECRET_KEY", OK, "live restricted key present (rk_live_)")
+    elif sk.startswith("sk_live_") or sk.startswith("rk_live_"):
+        # This app calls Checkout Session and Subscription reads (verify-session,
+        # webhook plan lookup). A restricted key (rk_live_) that's the wrong one
+        # or missing those scopes authenticates fine but 403s on exactly those
+        # calls — the prefix alone doesn't prove it works, so actually call it.
+        try:
+            import stripe as _stripe
+            _stripe.api_key = sk
+            _stripe.checkout.Session.list(limit=1)
+            _stripe.Subscription.list(limit=1)
+            kind = "restricted" if sk.startswith("rk_live_") else "full secret"
+            r.add("STRIPE_SECRET_KEY", OK,
+                  f"live {kind} key present and can read Checkout Sessions + Subscriptions")
+        except Exception as e:
+            r.add("STRIPE_SECRET_KEY", BLOCKER,
+                  f"live key present but the API rejected a real call: {e}",
+                  "if this is a restricted key (rk_live_), grant it Checkout Sessions: Read "
+                  "and Subscriptions: Read, or switch to the full sk_live_ secret key")
     else:
         r.add("STRIPE_SECRET_KEY", WARNING, "set but not a recognised Stripe key format",
               "expected sk_live_... or rk_live_... (or sk_test_... for sandbox)")
@@ -135,6 +149,45 @@ def run_checks() -> Report:
               "verify it is the endpoint's signing secret")
     else:
         r.add("STRIPE_WEBHOOK_SECRET", OK, "set (whsec_)")
+
+    # A correct whsec_ doesn't prove an endpoint pointing at THIS deployment is
+    # actually registered in Stripe — that's the failure mode that leaves every
+    # real payment stuck (session verified, but no License row, no email, ever).
+    if not _is_placeholder(sk):
+        try:
+            import stripe as _stripe
+            _stripe.api_key = sk
+            endpoints = _stripe.WebhookEndpoint.list(limit=20)
+            live_matches = [
+                e for e in endpoints.auto_paging_iter()
+                if e.get("url", "").rstrip("/").endswith("/webhook/stripe")
+                and e.get("status") == "enabled"
+            ]
+            if not live_matches:
+                r.add("Stripe webhook endpoint", BLOCKER,
+                      "no enabled endpoint in this Stripe account targets */webhook/stripe — "
+                      "checkout.session.completed will never reach this server",
+                      "dashboard.stripe.com → Developers → Webhooks → Add endpoint → "
+                      "https://<this-host>/webhook/stripe, events: checkout.session.completed, "
+                      "invoice.payment_succeeded, invoice.payment_failed, "
+                      "customer.subscription.updated, customer.subscription.deleted")
+            else:
+                needed = {"checkout.session.completed"}
+                for e in live_matches:
+                    events = set(e.get("enabled_events", []))
+                    if "*" in events or needed <= events:
+                        r.add("Stripe webhook endpoint", OK,
+                              f"{e['url']} is enabled and subscribed to checkout.session.completed")
+                        break
+                else:
+                    r.add("Stripe webhook endpoint", BLOCKER,
+                          f"endpoint {live_matches[0]['url']} exists but isn't subscribed to "
+                          "checkout.session.completed — licenses will never be created",
+                          "edit the endpoint in the Stripe dashboard and add that event")
+        except Exception as e:
+            r.add("Stripe webhook endpoint", WARNING,
+                  f"could not list webhook endpoints to verify ({e})",
+                  "this key may lack Webhook Endpoints: Read — check manually in the dashboard")
 
     # ── Email delivery (license keys reach buyers) ───────────────────────────
     send = os.environ.get("SEND_EMAIL_ENABLED", "false").lower() == "true"
@@ -152,22 +205,48 @@ def run_checks() -> Report:
     else:
         r.add("Email delivery", OK, f"enabled via {smtp_host}")
 
-    # ── Installer binaries ───────────────────────────────────────────────────
-    downloads = Path(os.environ.get("DOWNLOADS_DIR", "./downloads"))
-    if not downloads.is_absolute():
-        downloads = (Path(__file__).resolve().parent / downloads).resolve()
-    present = [p for p, f in PLATFORM_FILES.items() if (downloads / f).exists()]
-    missing = [p for p in PLATFORM_FILES if p not in present]
-    if not present:
+    # ── Installer binaries (served from a private GitHub release, not disk) ──
+    gh_repo = os.environ.get("GITHUB_RELEASES_REPO", "kaleidoscopeAI/goeckoh-releases")
+    gh_token = os.environ.get("GITHUB_RELEASES_TOKEN", "")
+    if _is_placeholder(gh_token):
         r.add("Installer binaries", BLOCKER,
-              f"none present in {downloads} — every /download returns 503",
-              f"stage at least one of: {', '.join(PLATFORM_FILES.values())}")
-    elif missing:
-        r.add("Installer binaries", WARNING,
-              f"present: {', '.join(present)}; missing: {', '.join(missing)}",
-              "those platforms' downloads will 503 until staged")
+              "GITHUB_RELEASES_TOKEN not set — every /download returns 503",
+              "create a fine-grained PAT with Contents:read on the releases repo, "
+              "set GITHUB_RELEASES_TOKEN")
     else:
-        r.add("Installer binaries", OK, "all four platforms staged")
+        try:
+            import requests
+            resp = requests.get(
+                f"https://api.github.com/repos/{gh_repo}/releases/latest",
+                headers={"Authorization": f"Bearer {gh_token}",
+                         "Accept": "application/vnd.github+json"},
+                timeout=10,
+            )
+            if resp.status_code != 200:
+                r.add("Installer binaries", BLOCKER,
+                      f"GitHub releases lookup failed ({resp.status_code}) for {gh_repo} — "
+                      "every /download returns 503",
+                      "check GITHUB_RELEASES_TOKEN has Contents:read on that repo, and that "
+                      "GITHUB_RELEASES_REPO is correct")
+            else:
+                names = {a["name"] for a in resp.json().get("assets", [])}
+                present = [p for p, f in PLATFORM_FILES.items() if f in names]
+                missing = [p for p in PLATFORM_FILES if p not in present]
+                if not present:
+                    r.add("Installer binaries", BLOCKER,
+                          f"latest release in {gh_repo} has none of the expected assets",
+                          f"upload: {', '.join(PLATFORM_FILES.values())}")
+                elif missing:
+                    r.add("Installer binaries", WARNING,
+                          f"present: {', '.join(present)}; missing: {', '.join(missing)}",
+                          "those platforms' downloads will 503 until uploaded")
+                else:
+                    r.add("Installer binaries", OK,
+                          f"all four platforms found in {gh_repo} latest release")
+        except Exception as e:
+            r.add("Installer binaries", WARNING,
+                  f"could not reach GitHub to verify ({e})",
+                  "check network egress to api.github.com from this host")
 
     # ── Admin endpoint guard ─────────────────────────────────────────────────
     admin = os.environ.get("ADMIN_SECRET", "")

--- a/backend/preflight.py
+++ b/backend/preflight.py
@@ -8,11 +8,14 @@ intend to deploy on:
 
     python preflight.py            # human-readable report; exit 1 if any BLOCKER
     python preflight.py --json     # machine-readable (for monitoring / CI)
+    python preflight.py --offline  # format/config checks only, no Stripe/GitHub calls
 
-It is also imported by main.py to log a one-line readiness summary on startup,
-so a half-configured server announces itself in the logs instead of failing
-silently at the worst moment (e.g. payment succeeds but no license email goes
-out because SMTP was never set).
+It is also imported by main.py to log a one-line readiness summary on startup
+(offline mode — see run_checks() docstring for why), so a half-configured
+server announces itself in the logs instead of failing silently at the worst
+moment (e.g. payment succeeds but no license email goes out because SMTP was
+never set). Run it interactively with live checks for the full picture,
+including whether Stripe is actually configured correctly end-to-end.
 
 No secret VALUES are ever printed — only whether each one is present and
 plausible. Safe to run anywhere, safe to paste the output.
@@ -95,7 +98,42 @@ class Report:
                 f"{len(self.warnings)} warning(s). Run `python preflight.py`.")
 
 
-def run_checks() -> Report:
+class _BoundedStripeClient:
+    """Temporarily swaps in a short-timeout Stripe HTTP client for the
+    duration of the `with` block, then restores whatever was there before.
+    stripe-python's default timeout is 80s — fine for a webhook handler
+    mid-request, much too long for a preflight probe that must not stall."""
+
+    def __init__(self, seconds: float = 8):
+        self._seconds = seconds
+        self._previous = None
+
+    def __enter__(self):
+        import stripe as _stripe
+        from stripe._http_client import RequestsClient
+        self._previous = _stripe.default_http_client
+        _stripe.default_http_client = RequestsClient(timeout=self._seconds)
+        return self
+
+    def __exit__(self, *exc):
+        import stripe as _stripe
+        _stripe.default_http_client = self._previous
+
+
+def run_checks(include_live_checks: bool = True) -> Report:
+    """`include_live_checks=True` (the default, used by the `python
+    preflight.py` CLI) makes real Stripe/GitHub API calls to catch failures a
+    format check can't see — e.g. a restricted Stripe key that authenticates
+    but is scoped wrong, or a webhook endpoint that was never registered.
+
+    main.py runs this synchronously on every process boot to log a readiness
+    summary; with `include_live_checks=True` that would mean every cold
+    start (this app scales to zero — `min_machines_running = 0`) blocks on
+    two Stripe round-trips and a GitHub round-trip before the server can
+    accept the request that triggered the start. main.py passes
+    `include_live_checks=False` so boot stays a pure format/config check —
+    offline, fast, can't be slowed or wedged by a third party being slow.
+    """
     r = Report()
 
     # ── JWT signing secret ───────────────────────────────────────────────────
@@ -118,23 +156,29 @@ def run_checks() -> Report:
         r.add("STRIPE_SECRET_KEY", WARNING, "TEST key (sk_test_) — sandbox only, not real sales",
               "swap to sk_live_... before public launch")
     elif sk.startswith("sk_live_") or sk.startswith("rk_live_"):
-        # This app calls Checkout Session and Subscription reads (verify-session,
-        # webhook plan lookup). A restricted key (rk_live_) that's the wrong one
-        # or missing those scopes authenticates fine but 403s on exactly those
-        # calls — the prefix alone doesn't prove it works, so actually call it.
-        try:
-            import stripe as _stripe
-            _stripe.api_key = sk
-            _stripe.checkout.Session.list(limit=1)
-            _stripe.Subscription.list(limit=1)
-            kind = "restricted" if sk.startswith("rk_live_") else "full secret"
+        kind = "restricted" if sk.startswith("rk_live_") else "full secret"
+        if not include_live_checks:
             r.add("STRIPE_SECRET_KEY", OK,
-                  f"live {kind} key present and can read Checkout Sessions + Subscriptions")
-        except Exception as e:
-            r.add("STRIPE_SECRET_KEY", BLOCKER,
-                  f"live key present but the API rejected a real call: {e}",
-                  "if this is a restricted key (rk_live_), grant it Checkout Sessions: Read "
-                  "and Subscriptions: Read, or switch to the full sk_live_ secret key")
+                  f"live {kind} key present (format only — run `python preflight.py` "
+                  "for a live scope check)")
+        else:
+            # This app calls Checkout Session and Subscription reads (verify-session,
+            # webhook plan lookup). A restricted key (rk_live_) that's the wrong one
+            # or missing those scopes authenticates fine but 403s on exactly those
+            # calls — the prefix alone doesn't prove it works, so actually call it.
+            try:
+                import stripe as _stripe
+                with _BoundedStripeClient():
+                    _stripe.api_key = sk
+                    _stripe.checkout.Session.list(limit=1)
+                    _stripe.Subscription.list(limit=1)
+                r.add("STRIPE_SECRET_KEY", OK,
+                      f"live {kind} key present and can read Checkout Sessions + Subscriptions")
+            except Exception as e:
+                r.add("STRIPE_SECRET_KEY", BLOCKER,
+                      f"live key present but the API rejected a real call: {e}",
+                      "if this is a restricted key (rk_live_), grant it Checkout Sessions: Read "
+                      "and Subscriptions: Read, or switch to the full sk_live_ secret key")
     else:
         r.add("STRIPE_SECRET_KEY", WARNING, "set but not a recognised Stripe key format",
               "expected sk_live_... or rk_live_... (or sk_test_... for sandbox)")
@@ -153,37 +197,75 @@ def run_checks() -> Report:
     # A correct whsec_ doesn't prove an endpoint pointing at THIS deployment is
     # actually registered in Stripe — that's the failure mode that leaves every
     # real payment stuck (session verified, but no License row, no email, ever).
-    if not _is_placeholder(sk):
+    # Events actually consumed by main.py's webhook handler: checkout.session.completed
+    # creates the license; the rest reactivate/grace/revoke it on the billing lifecycle.
+    _CRITICAL_EVENT = "checkout.session.completed"
+    _LIFECYCLE_EVENTS = {
+        "invoice.payment_succeeded", "invoice.payment_failed",
+        "customer.subscription.updated", "customer.subscription.deleted",
+    }
+    if not include_live_checks:
+        r.add("Stripe webhook endpoint", OK,
+              "not checked in offline mode — run `python preflight.py` to verify "
+              "a live endpoint is registered")
+    elif not _is_placeholder(sk):
+        # FLY_APP_NAME is set automatically by the Fly runtime. Without it (e.g. a
+        # local run) we can't know this deployment's own hostname, so we fall back
+        # to path-only matching and say so explicitly rather than silently
+        # trusting any endpoint anywhere that happens to end in /webhook/stripe.
+        fly_app = os.environ.get("FLY_APP_NAME", "")
+        expected_host = os.environ.get("PUBLIC_BACKEND_HOST", f"{fly_app}.fly.dev" if fly_app else "")
         try:
             import stripe as _stripe
-            _stripe.api_key = sk
-            endpoints = _stripe.WebhookEndpoint.list(limit=20)
-            live_matches = [
+            with _BoundedStripeClient():
+                _stripe.api_key = sk
+                endpoints = _stripe.WebhookEndpoint.list(limit=20)
+            candidates = [
                 e for e in endpoints.data
                 if e.get("url", "").rstrip("/").endswith("/webhook/stripe")
                 and e.get("status") == "enabled"
             ]
+            live_matches = (
+                [e for e in candidates if expected_host and expected_host in e.get("url", "")]
+                if expected_host else candidates
+            )
             if not live_matches:
+                host_note = f" targeting {expected_host}" if expected_host else ""
                 r.add("Stripe webhook endpoint", BLOCKER,
-                      "no enabled endpoint in this Stripe account targets */webhook/stripe — "
-                      "checkout.session.completed will never reach this server",
+                      f"no enabled endpoint in this Stripe account{host_note} targets "
+                      "*/webhook/stripe — checkout.session.completed will never reach this server",
                       "dashboard.stripe.com → Developers → Webhooks → Add endpoint → "
                       "https://<this-host>/webhook/stripe, events: checkout.session.completed, "
                       "invoice.payment_succeeded, invoice.payment_failed, "
                       "customer.subscription.updated, customer.subscription.deleted")
             else:
-                needed = {"checkout.session.completed"}
+                best = None
                 for e in live_matches:
                     events = set(e.get("enabled_events", []))
-                    if "*" in events or needed <= events:
-                        r.add("Stripe webhook endpoint", OK,
-                              f"{e['url']} is enabled and subscribed to checkout.session.completed")
+                    if "*" in events or _CRITICAL_EVENT in events:
+                        best = (e, events)
                         break
-                else:
+                if not best:
                     r.add("Stripe webhook endpoint", BLOCKER,
                           f"endpoint {live_matches[0]['url']} exists but isn't subscribed to "
-                          "checkout.session.completed — licenses will never be created",
+                          f"{_CRITICAL_EVENT} — licenses will never be created",
                           "edit the endpoint in the Stripe dashboard and add that event")
+                else:
+                    e, events = best
+                    missing_lifecycle = _LIFECYCLE_EVENTS - events if "*" not in events else set()
+                    if not expected_host:
+                        r.add("Stripe webhook endpoint", WARNING,
+                              f"{e['url']} matches on path only — set FLY_APP_NAME or "
+                              "PUBLIC_BACKEND_HOST to confirm it's actually this deployment")
+                    elif missing_lifecycle:
+                        r.add("Stripe webhook endpoint", WARNING,
+                              f"{e['url']} handles new purchases but is missing "
+                              f"{', '.join(sorted(missing_lifecycle))} — renewals, failed "
+                              "payments, and cancellations won't update the license",
+                              "add the missing events to this endpoint in the Stripe dashboard")
+                    else:
+                        r.add("Stripe webhook endpoint", OK,
+                              f"{e['url']} is enabled and subscribed to all events the app handles")
         except Exception as e:
             r.add("Stripe webhook endpoint", WARNING,
                   f"could not list webhook endpoints to verify ({e})",
@@ -213,6 +295,10 @@ def run_checks() -> Report:
               "GITHUB_RELEASES_TOKEN not set — every /download returns 503",
               "create a fine-grained PAT with Contents:read on the releases repo, "
               "set GITHUB_RELEASES_TOKEN")
+    elif not include_live_checks:
+        r.add("Installer binaries", OK,
+              "GITHUB_RELEASES_TOKEN present (format only — run `python preflight.py` "
+              "to confirm the release and assets actually exist)")
     else:
         try:
             import requests
@@ -307,7 +393,7 @@ def _print_report(r: Report) -> None:
 
 
 def main() -> int:
-    r = run_checks()
+    r = run_checks(include_live_checks="--offline" not in sys.argv)
     if "--json" in sys.argv:
         print(json.dumps({
             "ready": r.ready,

--- a/backend/static/portal.html
+++ b/backend/static/portal.html
@@ -126,9 +126,9 @@
     <h2>Download the app</h2>
     <p class="hint">Downloads are unlocked by your active license. Pick your platform.</p>
     <div class="grid4">
-      <button class="btn-soft dl" data-platform="mac"><strong>macOS</strong><small>.dmg</small></button>
-      <button class="btn-soft dl" data-platform="windows"><strong>Windows</strong><small>.exe</small></button>
-      <button class="btn-soft dl" data-platform="linux"><strong>Linux</strong><small>.deb</small></button>
+      <button class="btn-soft dl" data-platform="mac"><strong>macOS</strong><small>.tar.gz</small></button>
+      <button class="btn-soft dl" data-platform="windows"><strong>Windows</strong><small>.zip</small></button>
+      <button class="btn-soft dl" data-platform="linux"><strong>Linux</strong><small>.tar.gz</small></button>
       <button class="btn-soft dl" data-platform="android"><strong>Android</strong><small>.apk</small></button>
     </div>
     <div class="msg" id="downloadMsg"></div>


### PR DESCRIPTION
## **User description**
## Summary
- `preflight.py` still checked `DOWNLOADS_DIR` for local binary files, but `/download/{platform}` was switched to stream from GitHub Releases in the earlier merge — it was giving a false readiness signal on exactly the thing meant to catch a broken download path before a real customer pays. It now queries the GitHub Releases API directly and reports per-platform asset presence.
- Added a real functional check for `STRIPE_SECRET_KEY`: a restricted key (`rk_live_`) can authenticate but still 403 on the specific resources this app reads (Checkout Sessions, Subscriptions) if it wasn't scoped for them — the exact failure mode just diagnosed live on this account. Preflight now makes those calls instead of trusting the key prefix alone.
- Added a check for whether a Stripe webhook endpoint targeting `/webhook/stripe` is actually registered and subscribed to `checkout.session.completed` — without it, `/checkout/verify-session` still says "paid", but no `License` row or email is ever created.
- `portal.html` download buttons were labeled `.dmg`/`.exe`/`.deb`; the backend actually serves `.tar.gz`/`.zip`/`.tar.gz`/`.apk`. Fixed the labels to match.

## Test plan
- [x] `python3 -m py_compile preflight.py`
- [x] Ran `preflight.py` in a clean venv with no env vars set — all checks report correctly, no crashes.
- [x] Ran with a fake `sk_live_` key — new Stripe-call checks degrade to a clear BLOCKER/WARNING instead of crashing when the API is unreachable.
- [ ] Run `python preflight.py` against the real deployed `.env` (or check Fly boot logs) to get the actual go-live readiness report — this requires network access to `api.stripe.com`/`api.github.com` that this sandbox doesn't have.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Strengthen go-live preflight checks for Stripe and GitHub-hosted installers and align portal download labels with actual artifacts.

New Features:
- Add live Stripe key validation by performing real Checkout Session and Subscription read calls during preflight.
- Add verification that a Stripe webhook endpoint targeting /webhook/stripe exists, is enabled, and is subscribed to checkout.session.completed.
- Add preflight validation that installer binaries exist in the latest GitHub Release via the GitHub Releases API.

Bug Fixes:
- Correct portal download button labels to reflect the actual archive formats served for each platform.

Enhancements:
- Improve resilience and guidance of preflight checks by surfacing clear BLOCKER/WARNING messages for Stripe and GitHub misconfigurations.


___

## **CodeAnt-AI Description**
Tighten go-live checks and correct download labels in the portal

### What Changed
- Preflight now checks real Stripe access instead of trusting the key prefix, so it can catch keys that authenticate but still cannot read the payment data this app needs.
- It also verifies that a Stripe webhook endpoint for this deployment is actually enabled and subscribed to the payment-completed event, which prevents silent failures where payments succeed but licenses are never created.
- Installer checks now look at the latest GitHub release assets instead of local files, matching how downloads are actually served.
- The portal download buttons now show the file types users will really get for each platform.

### Impact
`✅ Fewer false go-live checks`
`✅ Fewer paid orders missing licenses`
`✅ Fewer broken download links`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup checks for production payments so configuration issues are caught earlier, including Stripe key access and webhook readiness.
  * Added better validation for app downloads by confirming the latest release files are available for supported platforms.
  * Updated platform download links for macOS, Windows, and Linux to match the available file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->