### PR TITLE
Add GitHub Actions pipeline for backend deploy and secret management

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -15,15 +15,17 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      FLY_APP: ${{ vars.FLY_APP_NAME || 'goeckoh-backend' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@v1
 
       - name: Deploy
         working-directory: backend
-        run: flyctl deploy --remote-only -a goeckoh-backend
+        run: flyctl deploy --remote-only -a "$FLY_APP"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,29 @@
+name: Deploy goeckoh-backend to Fly.io
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/deploy-backend.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-backend
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        working-directory: backend
+        run: flyctl deploy --remote-only -a goeckoh-backend
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/register-stripe-webhook.yml
+++ b/.github/workflows/register-stripe-webhook.yml
@@ -8,7 +8,7 @@ name: Register Stripe webhook endpoint
 #
 # Requires two GitHub Actions secrets (Settings → Secrets and variables →
 # Actions): STRIPE_SECRET_KEY (the live sk_live_/rk_live_ key — if restricted,
-# it needs Webhook Endpoints: Write) and FLY_API_TOKEN.
+# it needs Webhook Endpoints: Read+Write) and FLY_API_TOKEN.
 
 on:
   workflow_dispatch:
@@ -21,9 +21,11 @@ on:
 jobs:
   register:
     runs-on: ubuntu-latest
+    env:
+      FLY_APP: ${{ vars.FLY_APP_NAME || 'goeckoh-backend' }}
     steps:
       - name: Setup flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@v1
 
       - name: Create or verify webhook endpoint, sync signing secret to Fly
         env:
@@ -31,6 +33,12 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           BACKEND_HOST: ${{ github.event.inputs.backend_host }}
         run: |
+          for name in STRIPE_SECRET_KEY FLY_API_TOKEN BACKEND_HOST FLY_APP; do
+            if [ -z "${!name}" ]; then
+              echo "::error::$name is not set — add it under Settings > Secrets and variables > Actions (repo secret for STRIPE_SECRET_KEY/FLY_API_TOKEN, repo variable for FLY_APP_NAME if you want to override the default)."
+              exit 1
+            fi
+          done
           pip install --quiet stripe
           python3 - <<'PYEOF'
           import os, subprocess, sys
@@ -38,6 +46,7 @@ jobs:
 
           stripe.api_key = os.environ["STRIPE_SECRET_KEY"]
           host = os.environ["BACKEND_HOST"]
+          fly_app = os.environ["FLY_APP"]
           target_url = f"https://{host}/webhook/stripe"
           needed_events = [
               "checkout.session.completed",
@@ -46,6 +55,15 @@ jobs:
               "customer.subscription.updated",
               "customer.subscription.deleted",
           ]
+
+          def fly_has_secret(name: str) -> bool:
+              # `flyctl secrets list` only ever prints secret NAMES + digests,
+              # never values — safe to shell out to and safe to log.
+              out = subprocess.run(
+                  ["flyctl", "secrets", "list", "-a", fly_app],
+                  check=True, capture_output=True, text=True,
+              ).stdout
+              return any(line.split()[0] == name for line in out.splitlines()[1:] if line.split())
 
           existing = [
               e for e in stripe.WebhookEndpoint.list(limit=100).auto_paging_iter()
@@ -62,17 +80,48 @@ jobs:
                   )
                   print(f"Updated existing endpoint {ep['id']} — added missing events: {sorted(missing)}")
               else:
-                  print(f"Endpoint {ep['id']} already targets {target_url} with all needed events. Nothing to do.")
-              print("No new signing secret to push (endpoint already existed — its whsec_ was set when it was first created).")
-              sys.exit(0)
+                  print(f"Endpoint {ep['id']} already targets {target_url} with all needed events.")
+
+              # Stripe never re-exposes a signing secret after creation, so if this
+              # endpoint was created some other way (dashboard, a different CI run
+              # that failed after the Stripe call but before the Fly push) there is
+              # no way to recover it here. Reporting success without checking would
+              # be exactly the false-OK failure mode preflight.py was fixed to catch
+              # on the Fly side — check the same thing here instead of assuming it.
+              if fly_has_secret("STRIPE_WEBHOOK_SECRET"):
+                  print(f"{fly_app} already has STRIPE_WEBHOOK_SECRET set. Nothing further to do.")
+                  sys.exit(0)
+              else:
+                  print(
+                      f"::error::Endpoint {ep['id']} exists in Stripe, but {fly_app} has no "
+                      "STRIPE_WEBHOOK_SECRET set — Stripe can't re-issue the signing secret for "
+                      "an existing endpoint. Delete this endpoint in the Stripe dashboard "
+                      "(dashboard.stripe.com > Developers > Webhooks) and re-run this workflow "
+                      "to create a fresh one and push its secret automatically."
+                  )
+                  sys.exit(1)
 
           ep = stripe.WebhookEndpoint.create(url=target_url, enabled_events=needed_events)
           secret = ep["secret"]  # only ever returned once, at creation
+          print(f"::add-mask::{secret}")  # generated at runtime, not a registered
+                                            # GitHub secret — mask it explicitly so it
+                                            # can never appear in this log, including
+                                            # in a failure traceback below.
           print(f"Created webhook endpoint {ep['id']} for {target_url}")
 
-          subprocess.run(
-              ["flyctl", "secrets", "set", f"STRIPE_WEBHOOK_SECRET={secret}", "-a", "goeckoh-backend"],
-              check=True,
-          )
-          print("Pushed the new signing secret to goeckoh-backend as STRIPE_WEBHOOK_SECRET.")
+          try:
+              # `secrets import` reads KEY=VALUE from stdin, keeping the secret out
+              # of argv entirely (unlike `secrets set KEY=VALUE ...` as an arg).
+              subprocess.run(
+                  ["flyctl", "secrets", "import", "-a", fly_app],
+                  input=f"STRIPE_WEBHOOK_SECRET={secret}\n",
+                  text=True, check=True, capture_output=True,
+              )
+          except subprocess.CalledProcessError as e:
+              print("::error::flyctl secrets import failed — see stdout/stderr above (secret is masked).")
+              print(e.stdout)
+              print(e.stderr)
+              sys.exit(1)
+
+          print(f"Pushed the new signing secret to {fly_app} as STRIPE_WEBHOOK_SECRET.")
           PYEOF

--- a/.github/workflows/register-stripe-webhook.yml
+++ b/.github/workflows/register-stripe-webhook.yml
@@ -1,0 +1,78 @@
+name: Register Stripe webhook endpoint
+
+# One-time (idempotent, safe to re-run) setup: creates the live-mode Stripe
+# webhook endpoint that goeckoh-backend needs to turn a completed checkout
+# into a license + email, and pushes the resulting signing secret straight to
+# Fly. Run manually from the Actions tab whenever the backend's hostname
+# changes or you need to confirm the endpoint is still correctly configured.
+#
+# Requires two GitHub Actions secrets (Settings → Secrets and variables →
+# Actions): STRIPE_SECRET_KEY (the live sk_live_/rk_live_ key — if restricted,
+# it needs Webhook Endpoints: Write) and FLY_API_TOKEN.
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend_host:
+        description: "Backend hostname the webhook should point at"
+        required: true
+        default: "goeckoh-backend.fly.dev"
+
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Create or verify webhook endpoint, sync signing secret to Fly
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          BACKEND_HOST: ${{ github.event.inputs.backend_host }}
+        run: |
+          pip install --quiet stripe
+          python3 - <<'PYEOF'
+          import os, subprocess, sys
+          import stripe
+
+          stripe.api_key = os.environ["STRIPE_SECRET_KEY"]
+          host = os.environ["BACKEND_HOST"]
+          target_url = f"https://{host}/webhook/stripe"
+          needed_events = [
+              "checkout.session.completed",
+              "invoice.payment_succeeded",
+              "invoice.payment_failed",
+              "customer.subscription.updated",
+              "customer.subscription.deleted",
+          ]
+
+          existing = [
+              e for e in stripe.WebhookEndpoint.list(limit=100).auto_paging_iter()
+              if e["url"] == target_url and e["status"] == "enabled"
+          ]
+
+          if existing:
+              ep = existing[0]
+              missing = set(needed_events) - set(ep.get("enabled_events", []))
+              if missing and "*" not in ep.get("enabled_events", []):
+                  stripe.WebhookEndpoint.modify(
+                      ep["id"],
+                      enabled_events=sorted(set(ep["enabled_events"]) | set(needed_events)),
+                  )
+                  print(f"Updated existing endpoint {ep['id']} — added missing events: {sorted(missing)}")
+              else:
+                  print(f"Endpoint {ep['id']} already targets {target_url} with all needed events. Nothing to do.")
+              print("No new signing secret to push (endpoint already existed — its whsec_ was set when it was first created).")
+              sys.exit(0)
+
+          ep = stripe.WebhookEndpoint.create(url=target_url, enabled_events=needed_events)
+          secret = ep["secret"]  # only ever returned once, at creation
+          print(f"Created webhook endpoint {ep['id']} for {target_url}")
+
+          subprocess.run(
+              ["flyctl", "secrets", "set", f"STRIPE_WEBHOOK_SECRET={secret}", "-a", "goeckoh-backend"],
+              check=True,
+          )
+          print("Pushed the new signing secret to goeckoh-backend as STRIPE_WEBHOOK_SECRET.")
+          PYEOF

--- a/.github/workflows/sync-fly-secrets.yml
+++ b/.github/workflows/sync-fly-secrets.yml
@@ -15,9 +15,11 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      FLY_APP: ${{ vars.FLY_APP_NAME || 'goeckoh-backend' }}
     steps:
       - name: Setup flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@v1
 
       - name: Push non-empty secrets to Fly
         env:
@@ -31,19 +33,25 @@ jobs:
           GITHUB_RELEASES_TOKEN: ${{ secrets.GITHUB_RELEASES_TOKEN }}
         run: |
           set -e
-          args=()
+          if [ -z "$FLY_API_TOKEN" ]; then
+            echo "::error::FLY_API_TOKEN is not set — add it under Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+          lines=""
           for name in STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET JWT_SECRET_KEY \
                       ADMIN_SECRET SMTP_USER SMTP_PASS GITHUB_RELEASES_TOKEN; do
             value="${!name}"
             if [ -n "$value" ]; then
-              args+=("$name=$value")
+              lines="${lines}${name}=${value}"$'\n'
               echo "queued: $name"
             else
               echo "skipped (not set in GitHub secrets): $name"
             fi
           done
-          if [ "${#args[@]}" -eq 0 ]; then
+          if [ -z "$lines" ]; then
             echo "No secrets set in GitHub — nothing to push. Add them under Settings → Secrets and variables → Actions."
             exit 0
           fi
-          flyctl secrets set "${args[@]}" -a goeckoh-backend
+          # `secrets import` reads KEY=VALUE lines from stdin, keeping values out
+          # of argv (unlike `secrets set KEY=VALUE ...`).
+          printf '%s' "$lines" | flyctl secrets import -a "$FLY_APP"

--- a/.github/workflows/sync-fly-secrets.yml
+++ b/.github/workflows/sync-fly-secrets.yml
@@ -1,0 +1,49 @@
+name: Sync secrets to Fly.io
+
+# Pushes secret values stored in GitHub → Settings → Secrets and variables →
+# Actions onto the goeckoh-backend Fly app. Run this manually (Actions tab →
+# this workflow → Run workflow) after adding or rotating any of the GitHub
+# secrets it reads below. Nothing here ever touches a local machine or file —
+# add/update the secret in GitHub's UI, then run this.
+#
+# Only secrets that are actually set in GitHub are pushed, so leaving one
+# unset here does not blank it out on Fly.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Push non-empty secrets to Fly
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+          ADMIN_SECRET: ${{ secrets.ADMIN_SECRET }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          GITHUB_RELEASES_TOKEN: ${{ secrets.GITHUB_RELEASES_TOKEN }}
+        run: |
+          set -e
+          args=()
+          for name in STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET JWT_SECRET_KEY \
+                      ADMIN_SECRET SMTP_USER SMTP_PASS GITHUB_RELEASES_TOKEN; do
+            value="${!name}"
+            if [ -n "$value" ]; then
+              args+=("$name=$value")
+              echo "queued: $name"
+            else
+              echo "skipped (not set in GitHub secrets): $name"
+            fi
+          done
+          if [ "${#args[@]}" -eq 0 ]; then
+            echo "No secrets set in GitHub — nothing to push. Add them under Settings → Secrets and variables → Actions."
+            exit 0
+          fi
+          flyctl secrets set "${args[@]}" -a goeckoh-backend


### PR DESCRIPTION
## **User description**
## Summary
Deploys and secret rotation for `goeckoh-backend` currently require a laptop with `flyctl` authenticated and network access to fly.io. The frontend's GitHub Pages deploy is already fully automated (`.github/workflows/deploy.yml`); the backend never got the same treatment. This adds three workflows so nothing about running this product requires a local machine again:

- **`deploy-backend.yml`** — auto-deploys `backend/` to Fly on every push to `main` that touches it, plus manual dispatch.
- **`sync-fly-secrets.yml`** — manual dispatch. Pushes whichever of `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `JWT_SECRET_KEY`, `ADMIN_SECRET`, `SMTP_USER`, `SMTP_PASS`, `GITHUB_RELEASES_TOKEN` are set as GitHub Actions secrets onto the Fly app. Secrets live in GitHub's own secret store from here on, not a local `.env` file.
- **`register-stripe-webhook.yml`** — manual dispatch, idempotent. Creates the live Stripe webhook endpoint directly via the Stripe API (or adds any missing event to an existing one) and pushes the resulting `whsec_...` straight to Fly. This closes the exact gap diagnosed earlier in this project — no live-mode webhook was registered, so paid checkouts verified fine but no license or email was ever created.

## Setup required (one-time, in GitHub's UI — Settings → Secrets and variables → Actions)
- `FLY_API_TOKEN` — required by all three workflows. Generate via `flyctl tokens create deploy -a goeckoh-backend`, or Fly's dashboard.
- `STRIPE_SECRET_KEY` — required by `sync-fly-secrets` and `register-stripe-webhook`.
- The rest (`JWT_SECRET_KEY`, `ADMIN_SECRET`, `SMTP_USER`, `SMTP_PASS`, `GITHUB_RELEASES_TOKEN`) as needed — `sync-fly-secrets` skips any that aren't set rather than blanking them out on Fly.

Bootstrapping `FLY_API_TOKEN` and `STRIPE_SECRET_KEY` still requires visiting Fly's and Stripe's own dashboards once each — neither GitHub nor these workflows can mint credentials for another company's service. Everything after that one-time setup runs from GitHub Actions.

## Test plan
- [x] All three workflow files pass `yaml.safe_load`.
- [x] The embedded Python in `register-stripe-webhook.yml` compiles standalone.
- [ ] Run `sync-fly-secrets` and `register-stripe-webhook` for real once the GitHub secrets above are added — needs `FLY_API_TOKEN`/`STRIPE_SECRET_KEY` that this sandbox doesn't have.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Introduce GitHub Actions workflows to automate backend deployment, secret synchronization, and Stripe webhook registration for the goeckoh-backend Fly.io app.

New Features:
- Add automated workflow to deploy the goeckoh-backend to Fly.io on main branch changes or manual trigger.
- Add workflow to sync selected GitHub Actions secrets to Fly.io app secrets without using local machines.
- Add workflow to create or update the live Stripe webhook endpoint and propagate its signing secret to Fly.io.


___

## **CodeAnt-AI Description**
Automate backend deploys, secret syncing, and Stripe webhook setup from GitHub

### What Changed
- Backend changes on `main` now deploy to Fly automatically, with a manual run option when needed
- GitHub-stored secrets can now be pushed to Fly in one manual workflow, and only secrets that are set are copied over
- Stripe’s live webhook can now be created or checked from GitHub, and its signing secret is pushed to Fly for license and email handling
- The webhook setup now keeps the required event list in sync instead of leaving the backend with an incomplete live Stripe connection

### Impact
`✅ No local deploys needed for backend releases`
`✅ Faster secret rotation`
`✅ Fewer missing Stripe webhook issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
