### PR TITLE
Add human-stakes section to homepage, name TBI explicitly

### DIFF
--- a/goeckoh-site/index.html
+++ b/goeckoh-site/index.html
@@ -154,6 +154,23 @@
     .prob-label { font-size:0.88rem; color:var(--gk-text); font-weight:700; margin-bottom:0.4rem; }
     .prob-desc { font-size:0.79rem; color:var(--gk-text-2); line-height:1.7; }
 
+    /* ── MOMENTS (human stakes, not mechanism) ───────────────────────── */
+    .moments-grid {
+      display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:1.5rem; margin-top:3rem;
+    }
+    .moment-card {
+      background:var(--gk-bg-card); border:1px solid var(--gk-border);
+      border-radius:var(--gk-radius); padding:2.1rem 1.85rem;
+    }
+    .moment-tag {
+      display:inline-block; font-size:0.66rem; font-weight:700; letter-spacing:0.09em;
+      text-transform:uppercase; color:var(--gk-teal); background:rgba(20,197,145,0.1);
+      border:1px solid rgba(20,197,145,0.22); border-radius:999px; padding:0.25rem 0.7rem;
+      margin-bottom:1.1rem;
+    }
+    .moment-title { font-size:1.08rem; font-weight:800; color:var(--gk-text); margin-bottom:0.65rem; line-height:1.3; }
+    .moment-desc { font-size:0.85rem; color:var(--gk-text-2); line-height:1.8; }
+
     /* ── HOW IT WORKS ─────────────────────────────────────────────── */
     .steps { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:1.5rem; margin-top:3rem; }
     .step-card {
@@ -382,6 +399,50 @@
         Your voice enters. Corrected, it returns.<br>
         The brain hears itself succeed.
       </p>
+    </div>
+  </div>
+</section>
+
+<!-- WHAT THIS ACTUALLY CHANGES -->
+<section>
+  <div class="gk-container">
+    <span class="eyebrow">What This Actually Changes</span>
+    <h2 class="section-title">Not louder. Not slower.<br>Understood.</h2>
+    <p class="section-sub">
+      The words are already there. What's missing is the loop between saying them and
+      hearing how they landed — the loop every fluent speaker relies on without thinking
+      about it. Goeckoh closes that loop, in the moment it's needed.
+    </p>
+    <div class="moments-grid">
+      <div class="moment-card">
+        <span class="moment-tag">Autism</span>
+        <div class="moment-title">Not repeating yourself five times</div>
+        <p class="moment-desc">
+          A teacher, a cousin, a cashier — understanding on the first try instead of the
+          third or fourth. That's not a small thing when it happens dozens of times a day.
+          Goeckoh works in the moment the words are spoken, not after the fact.
+        </p>
+      </div>
+      <div class="moment-card">
+        <span class="moment-tag">Stroke &amp; TBI</span>
+        <div class="moment-title">Getting a voice back, not a new one</div>
+        <p class="moment-desc">
+          After a stroke or traumatic brain injury, speech is often the last thing to
+          return — and the slowest, because clinic time is scarce and healing needs
+          repetition. Goeckoh gives the brain the same kind of real-time correction signal
+          a therapy session provides, available every time you speak, not once a week.
+        </p>
+      </div>
+      <div class="moment-card">
+        <span class="moment-tag">Apraxia</span>
+        <div class="moment-title">The gap between meaning it and saying it</div>
+        <p class="moment-desc">
+          Apraxia isn't about knowing the word — it's the signal from brain to mouth
+          losing precision on the way out. Goeckoh corrects inside that same window,
+          while the brain is still forming the sound, instead of surfacing the mismatch
+          later in a session note.
+        </p>
+      </div>
     </div>
   </div>
 </section>
@@ -676,7 +737,7 @@
           <li>Works at home, at school, at the grocery store, anywhere</li>
           <li>Guardian real-time monitoring from a separate device</li>
           <li>Designed for children and adults with ASD</li>
-          <li>Also effective for dysarthria, apraxia, and post-stroke speech</li>
+          <li>Also effective for dysarthria, apraxia, and speech changes from stroke or traumatic brain injury (TBI)</li>
           <li>No synthetic voice — your child sounds like themselves</li>
           <li>Your child's data never leaves their device</li>
         </ul>

--- a/goeckoh-site/index.html
+++ b/goeckoh-site/index.html
@@ -416,7 +416,7 @@
     <div class="moments-grid">
       <div class="moment-card">
         <span class="moment-tag">Autism</span>
-        <div class="moment-title">Not repeating yourself five times</div>
+        <h3 class="moment-title">Not repeating yourself five times</h3>
         <p class="moment-desc">
           A teacher, a cousin, a cashier — understanding on the first try instead of the
           third or fourth. That's not a small thing when it happens dozens of times a day.
@@ -425,9 +425,9 @@
       </div>
       <div class="moment-card">
         <span class="moment-tag">Stroke &amp; TBI</span>
-        <div class="moment-title">Getting a voice back, not a new one</div>
+        <h3 class="moment-title">Getting a voice back, not a new one</h3>
         <p class="moment-desc">
-          After a stroke or traumatic brain injury, speech is often the last thing to
+          After a stroke or traumatic brain injury (TBI), speech is often the last thing to
           return — and the slowest, because clinic time is scarce and healing needs
           repetition. Goeckoh gives the brain the same kind of real-time correction signal
           a therapy session provides, available every time you speak, not once a week.
@@ -435,7 +435,7 @@
       </div>
       <div class="moment-card">
         <span class="moment-tag">Apraxia</span>
-        <div class="moment-title">The gap between meaning it and saying it</div>
+        <h3 class="moment-title">The gap between meaning it and saying it</h3>
         <p class="moment-desc">
           Apraxia isn't about knowing the word — it's the signal from brain to mouth
           losing precision on the way out. Goeckoh corrects inside that same window,


### PR DESCRIPTION
## **User description**
## Summary
Feedback was that the homepage reads cold for a product aimed at people with autism, TBI, and other speech disorders — it's all mechanism (latency numbers, DIVA model citations, "biological window" language) with no human stakes, and TBI wasn't named explicitly anywhere.

- Added a new section right after the hero, before the neuroscience trust bar: three short, specific scenarios (autism, stroke/TBI, apraxia) about the actual barrier being removed — not before/after transformation framing, which risks reading as "fixing" a person rather than removing an obstacle between them and being understood.
- Named traumatic brain injury explicitly in the "For Families" bullet list; it was previously folded into "post-stroke speech" only.

This is frontend-only (`goeckoh-site/index.html`) — no backend, secrets, or Fly.io changes. Deploys automatically via the existing GitHub Pages workflow on merge.

## Test plan
- [x] Verified `<section>`/`</div>` balance unchanged (no broken markup)
- [x] Rendered locally via Playwright and visually confirmed the new section matches the existing design system (screenshot reviewed)
- [ ] Live visual check on goeckoh.com after merge (GitHub Pages deploy is automatic)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Add a new homepage section that highlights real-world communication scenarios and name traumatic brain injury explicitly as a supported use case.

New Features:
- Introduce a 'What This Actually Changes' section on the homepage with scenario-based cards for autism, stroke/TBI, and apraxia.

Enhancements:
- Clarify marketing copy to emphasize human impact over technical mechanisms for key user groups.


___

## **CodeAnt-AI Description**
**Add a human-stakes homepage section and name traumatic brain injury explicitly**

### What Changed
- Added a new homepage section that explains the real-life communication moments this product changes for autism, stroke/TBI, and apraxia.
- Replaced a mechanism-first message with plain-language examples focused on being understood in daily situations.
- Updated the Families section to mention traumatic brain injury explicitly instead of grouping it under post-stroke speech.

### Impact
`✅ Clearer homepage messaging for families and patients`
`✅ Easier discovery for people searching for TBI support`
`✅ Stronger fit between the homepage and real-world communication needs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “What This Actually Changes” section to highlight real-world impact for autism, stroke/TBI, and apraxia.
  * Introduced updated visual styling for a “Moments” layout with card-based content.
* **Content Updates**
  * Refined clinician-facing guidance to more clearly include dysarthria, apraxia, and speech changes related to stroke or traumatic brain injury.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->