### PR TITLE
Fix three error messages pointing at a nonexistent goeckoh.com/account

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -81,6 +81,16 @@ PLAN_MAX_DEVICES = {
     PlanTier.CLINICIAN: 10,
 }
 
+# The account portal is served by this app at /account (see account_portal()
+# below) — it is NOT at goeckoh.com/account, which doesn't exist (goeckoh.com
+# is static GitHub Pages hosting with no server-side routing). Same
+# PUBLIC_BACKEND_HOST fallback preflight.py uses, so this stays correct
+# without a second hardcoded value if the backend ever moves to a custom
+# domain in front of Fly.
+PUBLIC_ACCOUNT_URL = "https://" + os.environ.get(
+    "PUBLIC_BACKEND_HOST", os.environ.get("FLY_APP_NAME", "goeckoh-backend") + ".fly.dev"
+) + "/account"
+
 if not STRIPE_SECRET_KEY:
     logging.warning("STRIPE_SECRET_KEY not set — Stripe operations will fail")
 if not JWT_SECRET:
@@ -382,7 +392,7 @@ async def activate_license(request: Request, body: ActivateRequest, db: Session 
             raise HTTPException(
                 403,
                 f"Device limit reached ({lic.max_devices} devices for {lic.plan.value} plan). "
-                "Deactivate a device at goeckoh.com/account or upgrade your plan."
+                f"Deactivate a device at {PUBLIC_ACCOUNT_URL} or upgrade your plan."
             )
         device = Device(
             license_id=lic.id,
@@ -450,7 +460,7 @@ async def validate_license(request: Request, body: ValidateRequest, db: Session 
             "plan": lic.plan.value,
             "expires_in_days": 3,
             "status": "grace_period",
-            "warning": "Payment failed. Please update your payment method at goeckoh.com/account.",
+            "warning": f"Payment failed. Please update your payment method at {PUBLIC_ACCOUNT_URL}.",
         }
 
     # Enforce device limit — same logic as activate so validate can't bypass it
@@ -473,7 +483,7 @@ async def validate_license(request: Request, body: ValidateRequest, db: Session 
             raise HTTPException(
                 403,
                 f"Device limit reached ({lic.max_devices} devices for {lic.plan.value} plan). "
-                "Deactivate a device at goeckoh.com/account or upgrade your plan."
+                f"Deactivate a device at {PUBLIC_ACCOUNT_URL} or upgrade your plan."
             )
         device = Device(
             license_id=lic.id,


### PR DESCRIPTION
## **User description**
## Summary
Found while writing the homepage FAQ content in #34: three user-facing error/warning messages (device-limit-reached in both `/license/activate` and `/license/validate`, and the payment-failed grace-period warning) tell customers to go to `goeckoh.com/account` — that page doesn't exist. `goeckoh.com` is static GitHub Pages hosting with no server-side routing; the real account portal is served by this app itself at `/account`.

Added `PUBLIC_ACCOUNT_URL`, constructed the same way `preflight.py`'s webhook host check already does (`PUBLIC_BACKEND_HOST` env override, falling back to `FLY_APP_NAME.fly.dev`) — one place to get right instead of three hardcoded strings, and it stays correct automatically if a custom domain ever fronts this app.

## Test plan
- [x] `python3 -m py_compile main.py`
- [x] Verified no remaining `goeckoh.com/account` references in code (only in an explanatory comment)
- [x] Verified the fallback URL construction resolves to the actual working portal URL (`https://goeckoh-backend.fly.dev/account`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Update license error and warning messages to point to the correct account portal URL and centralize its construction via a configurable PUBLIC_ACCOUNT_URL.

Bug Fixes:
- Correct user-facing links in license activation, validation, and payment failure messages to use the actual in-app account portal instead of a nonexistent goeckoh.com/account URL.

Enhancements:
- Introduce a PUBLIC_ACCOUNT_URL constant derived from PUBLIC_BACKEND_HOST or FLY_APP_NAME to avoid hardcoded account portal links and keep them accurate across deployments.


___

## **CodeAnt-AI Description**
**Point account-related errors to the working portal**

### What Changed
- Device-limit errors now send users to the real account portal instead of a broken `goeckoh.com/account` link
- Payment-failed warnings now point to the same working account page for updating billing details
- The account link is now set in one place so these messages stay consistent across deployments

### Impact
`✅ Fewer broken help links`
`✅ Clearer device-limit recovery`
`✅ Easier payment-method updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
