### PR TITLE
Fix near-silent Hear-The-Correction playback in the demo

### DIFF
--- a/goeckoh-site/demo.html
+++ b/goeckoh-site/demo.html
@@ -1363,6 +1363,14 @@ let vowelHistory = [];
 /* ── Hear-It state ─────────────────────────────────────────── */
 let workletNode = null, hearItActive = false, hearItTimer = null, hearItRemaining = 0;
 let hearItModuleLoaded = false; // registerProcessor() may only run once per AudioContext
+let hearItGainNode = null, hearItLimiterNode = null;
+// Mic capture below deliberately disables autoGainControl (see getUserMedia call) so the
+// browser's AGC doesn't pump/distort the signal the formant analysis depends on — but that
+// also means the raw signal reaching here is much quieter than any normal call/recording
+// app, since nothing else boosts it. Made up for on the OUTPUT side only: a fixed gain
+// boost, followed by a soft-clip curve so a loud talker doesn't produce harsh digital
+// clipping instead of just louder correction.
+const HEARIT_OUTPUT_GAIN = 3.5;
 const hearItBtn         = document.getElementById('hearItBtn');
 const hearItCountdown   = document.getElementById('hearItCountdown');
 const hearItCountdownTxt= document.getElementById('hearItCountdownTxt');
@@ -1627,8 +1635,16 @@ async function toggleHearIt() {
     workletNode = new AudioWorkletNode(audioCtx, 'goeckoh-demo-processor', {
       numberOfInputs: 1, numberOfOutputs: 1, outputChannelCount: [1],
     });
+    hearItGainNode = audioCtx.createGain();
+    hearItGainNode.gain.value = HEARIT_OUTPUT_GAIN;
+    hearItLimiterNode = audioCtx.createWaveShaper();
+    hearItLimiterNode.curve = makeSoftClipCurve();
+    hearItLimiterNode.oversample = '2x';
+
     micSourceNode.connect(workletNode);
-    workletNode.connect(audioCtx.destination);
+    workletNode.connect(hearItGainNode);
+    hearItGainNode.connect(hearItLimiterNode);
+    hearItLimiterNode.connect(audioCtx.destination);
     pushHearItParams();
 
     hearItActive = true;
@@ -1661,10 +1677,24 @@ function pushHearItParams() {
   workletNode.port.postMessage({ tF1: p.f1, tF2: p.f2, str: 0.6, wet: 1.0, active: true });
 }
 
+// Symmetric tanh soft-clip: near-linear (≈unity slope) well below full scale, rolling off
+// smoothly into ±1 instead of hard-clipping — so HEARIT_OUTPUT_GAIN can be generous for
+// quiet talkers without loud talkers getting harsh digital clipping artifacts.
+function makeSoftClipCurve(samples = 1024) {
+  const curve = new Float32Array(samples);
+  for (let i = 0; i < samples; i++) {
+    const x = (i / (samples - 1)) * 2 - 1;
+    curve[i] = Math.tanh(x * 1.5) / Math.tanh(1.5);
+  }
+  return curve;
+}
+
 function stopHearIt() {
   clearInterval(hearItTimer);
   hearItTimer = null;
-  if (workletNode) { try { workletNode.disconnect(); } catch (e) {} workletNode = null; }
+  if (workletNode)       { try { workletNode.disconnect(); }       catch (e) {} workletNode = null; }
+  if (hearItGainNode)    { try { hearItGainNode.disconnect(); }    catch (e) {} hearItGainNode = null; }
+  if (hearItLimiterNode) { try { hearItLimiterNode.disconnect(); } catch (e) {} hearItLimiterNode = null; }
   hearItActive = false;
   hearItBtn.classList.remove('playing');
   hearItBtn.textContent = '🎧  Hear The Correction';

--- a/goeckoh-site/demo.html
+++ b/goeckoh-site/demo.html
@@ -1370,7 +1370,7 @@ let hearItGainNode = null, hearItLimiterNode = null;
 // app, since nothing else boosts it. Made up for on the OUTPUT side only: a fixed gain
 // boost, followed by a soft-clip curve so a loud talker doesn't produce harsh digital
 // clipping instead of just louder correction.
-const HEARIT_OUTPUT_GAIN = 3.5;
+const HEARIT_OUTPUT_GAIN = 3.5; // linear pre-shaper boost — see makeSoftClipCurve() below
 const hearItBtn         = document.getElementById('hearItBtn');
 const hearItCountdown   = document.getElementById('hearItCountdown');
 const hearItCountdownTxt= document.getElementById('hearItCountdownTxt');
@@ -1638,7 +1638,7 @@ async function toggleHearIt() {
     hearItGainNode = audioCtx.createGain();
     hearItGainNode.gain.value = HEARIT_OUTPUT_GAIN;
     hearItLimiterNode = audioCtx.createWaveShaper();
-    hearItLimiterNode.curve = makeSoftClipCurve();
+    hearItLimiterNode.curve = HEARIT_SOFTCLIP_CURVE;
     hearItLimiterNode.oversample = '2x';
 
     micSourceNode.connect(workletNode);
@@ -1677,9 +1677,15 @@ function pushHearItParams() {
   workletNode.port.postMessage({ tF1: p.f1, tF2: p.f2, str: 0.6, wet: 1.0, active: true });
 }
 
-// Symmetric tanh soft-clip: near-linear (≈unity slope) well below full scale, rolling off
-// smoothly into ±1 instead of hard-clipping — so HEARIT_OUTPUT_GAIN can be generous for
-// quiet talkers without loud talkers getting harsh digital clipping artifacts.
+// Symmetric tanh soft-clip, normalized so tanh(1.5)/tanh(1.5) = 1 at full scale. Note this
+// does NOT have unity slope at the origin — the derivative at x=0 is 1.5/tanh(1.5) ≈ 1.66,
+// so quiet input gets a further ≈1.66x boost on top of HEARIT_OUTPUT_GAIN (≈5.8x combined
+// low-level gain), tapering smoothly toward ±1 as input approaches full scale. That extra
+// low-level boost is wanted here, not a bug — the whole point of this chain is quiet mic
+// input (autoGainControl is off) reading as too faint; the curve just keeps a loud talker
+// from hitting a hard digital ceiling instead of a smooth one.
+// Built once at module scope — the shape never changes, so no reason to reallocate a
+// Float32Array every time Hear-It starts.
 function makeSoftClipCurve(samples = 1024) {
   const curve = new Float32Array(samples);
   for (let i = 0; i < samples; i++) {
@@ -1688,10 +1694,16 @@ function makeSoftClipCurve(samples = 1024) {
   }
   return curve;
 }
+const HEARIT_SOFTCLIP_CURVE = makeSoftClipCurve();
 
 function stopHearIt() {
   clearInterval(hearItTimer);
   hearItTimer = null;
+  // micSourceNode.connect(workletNode) (in toggleHearIt) is an upstream connection from a
+  // node that outlives Hear-It sessions — disconnecting workletNode's own output doesn't
+  // remove it, so without this, each start/stop cycle leaves another orphaned worklet
+  // hanging off micSourceNode, still processing audio it can no longer be heard from.
+  if (workletNode && micSourceNode) { try { micSourceNode.disconnect(workletNode); } catch (e) {} }
   if (workletNode)       { try { workletNode.disconnect(); }       catch (e) {} workletNode = null; }
   if (hearItGainNode)    { try { hearItGainNode.disconnect(); }    catch (e) {} hearItGainNode = null; }
   if (hearItLimiterNode) { try { hearItLimiterNode.disconnect(); } catch (e) {} hearItLimiterNode = null; }


### PR DESCRIPTION
## **User description**
## Summary
Reported directly: the corrected-audio playback in `demo.html`'s "Hear The Correction" mode was so faint it read as broken, not just quiet.

Root cause: mic capture deliberately sets `autoGainControl: false` (correct — the browser's AGC would pump/distort the signal the formant analysis depends on), but nothing on the *output* side compensates for that, so playback is just the raw, un-boosted mic signal after formant filtering — much quieter than any normal call/recording app.

Fix: a `GainNode` (3.5x boost) + a `WaveShaper` soft-clip limiter, inserted between the correction worklet and `audioCtx.destination`. Output-side only — the analysis input path is untouched, so formant tracking accuracy isn't affected. The limiter means a loud talker gets louder correction, not harsh digital clipping.

## Test plan
- [x] Verified via Playwright with a fake audio device (`--use-fake-device-for-media-stream`) that the gain/limiter nodes build correctly (`gain=3.5`, 2x-oversampled soft-clip curve, 1024-sample curve)
- [x] Confirmed `audioCtx.state` stays `'running'` through a full start → Hear It → stop cycle
- [x] Confirmed both new nodes are properly disconnected and nulled on `stopHearIt()` (no dangling audio graph nodes across repeated sessions)
- [ ] Live check with a real microphone/speakers after merge — the fake-device test proves the graph builds and runs correctly, but I can't judge actual perceived loudness without a real audio device


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Improve the demo's Hear-The-Correction playback loudness while preserving analysis integrity.

Enhancements:
- Add an output gain stage and soft-clip limiter to the Hear-It audio path to bring corrected playback up to a more usable level without introducing harsh clipping.
- Ensure Hear-It audio nodes (worklet, gain, limiter) are properly created, wired, and cleaned up when starting and stopping playback.


___

## **CodeAnt-AI Description**
**Make Hear The Correction playback louder and clearer in the demo**

### What Changed
- The demo’s corrected playback now includes an output boost, so the Hear The Correction mode is no longer near-silent.
- A soft limiter is added after the boost to keep loud voices from producing harsh clipping.
- The hearing-correction audio pieces are now cleaned up when stopping playback, preventing leftover audio behavior across repeated sessions.

### Impact
`✅ Clearer Hear The Correction playback`
`✅ Fewer “broken audio” impressions in the demo`
`✅ Less clipping on loud corrected speech`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio playback handling for Hear-It, resulting in more consistent output volume and reduced clipping/distortion.
  * Made stop actions more reliable by ensuring playback components are fully disconnected and cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->