### PR TITLE
Fix demo correction filter using wrong sample rate on non-48kHz devices

### DIFF
--- a/goeckoh-site/demo.html
+++ b/goeckoh-site/demo.html
@@ -1556,14 +1556,20 @@ class GoeckohDemoProcessor extends AudioWorkletProcessor {
     for (let i = 1; i < n; i++) { const hw = 0.54 - 0.46 * Math.cos(2 * Math.PI * i / (n - 1)); w[i] = (frm[i] - 0.97 * frm[i - 1]) * hw; }
     this.peZ = frm[n - 1];
     const a = this.ldLPC(w, this.ORDER);
-    const [F1, F2] = this.formants(a, this.ORDER, 16000);
+    const [F1, F2] = this.formants(a, this.ORDER, sampleRate / this.DEC);
     this.sF1 = this.AL * this.sF1 + (1 - this.AL) * F1;
     this.sF2 = this.AL * this.sF2 + (1 - this.AL) * F2;
     if (this.active && this.tF1 != null && this.tF2 != null) {
       const c1 = this.sF1 + this.str * (this.tF1 - this.sF1);
       const c2 = this.sF2 + this.str * (this.tF2 - this.sF2);
-      this.bq1c = Math.abs(this.sF1 - c1) > 15 ? this.bqMake(this.sF1, c1, 48000, 90)  : null;
-      this.bq2c = Math.abs(this.sF2 - c2) > 15 ? this.bqMake(this.sF2, c2, 48000, 120) : null;
+      // bqMake's frequency math is relative to whatever sample rate this
+      // AudioWorklet is actually running at — hardcoding 48000 here silently
+      // placed the correction filter's pole/zero at the wrong frequencies on
+      // any device/browser that didn't grant the requested 48kHz context rate
+      // (common over Bluetooth, where HFP mic profiles often force 16kHz),
+      // which sounds like added resonant coloration instead of a clean shift.
+      this.bq1c = Math.abs(this.sF1 - c1) > 15 ? this.bqMake(this.sF1, c1, sampleRate, 90)  : null;
+      this.bq2c = Math.abs(this.sF2 - c2) > 15 ? this.bqMake(this.sF2, c2, sampleRate, 120) : null;
     } else { this.bq1c = null; this.bq2c = null; }
   }
   process(inputs, outputs) {


### PR DESCRIPTION
## Summary
Reported: the demo's "Hear The Correction" mode was cluttering the voice instead of correcting it.

Root cause: the worklet requests a 48kHz `AudioContext`, but browsers aren't required to honor that — many devices and audio paths (especially Bluetooth HFP mic profiles, exactly what this product recommends) negotiate a different real sample rate. Both the formant analysis and the correction biquad filters hardcoded `16000`/`48000` Hz instead of reading the AudioWorklet's actual runtime `sampleRate`, so on any device that didn't grant 48kHz, the correction filter's pole/zero pair landed at the wrong frequencies relative to the real audio.

## Verification
Extracted the worklet's DSP into a standalone Node harness and ran it against synthetic vowel-like input at several real-world sample rates:

| Rate | Old (hardcoded) | Fixed (real rate) |
|---|---|---|
| 48000 Hz | stable, correct | stable, correct (identical — this was the assumed rate) |
| 44100 Hz | pole off by ~26 Hz | correct |
| 16000 Hz | **output energy 5.4x input, peak samples at 1.57 (≈4x over full scale), correction landing at 366 Hz instead of ~590 Hz** | stable, correct |

At 16kHz — a plausible real-world rate over Bluetooth — the old code produced a near-unstable filter that massively amplifies and distorts the signal instead of cleanly shifting formants. That matches "cluttering the voice instead of correcting it" exactly.

Also confirmed no regression in-browser via Playwright with a fake audio device: AudioContext runs, worklet initializes and processes audio normally, teardown on stop is clean. (The sandbox's fake device happens to negotiate exactly 48000 Hz, which is why this wouldn't have shown up in that kind of test alone — it only manifests on real hardware/Bluetooth paths that don't grant 48kHz.)

## Test plan
- [x] Standalone DSP harness comparing old vs. fixed code at 48000/44100/16000 Hz (see table above)
- [x] Playwright end-to-end: demo starts, Hear-The-Correction activates, worklet runs, clean teardown, zero console/page errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Use the AudioWorklet’s actual runtime sample rate for formant analysis and correction filters so the demo’s “Hear The Correction” mode behaves consistently across devices.

Bug Fixes:
- Fix formant estimation and correction filters to operate at the AudioWorklet’s real sample rate instead of hardcoded 16kHz/48kHz values, preventing severe distortion on non‑48kHz devices.

Enhancements:
- Clarify in-code documentation around the correction filter’s dependence on the AudioWorklet’s negotiated sample rate.