### PR TITLE
Fix demo's live formant readout using the same wrong-sample-rate bug

### DIFF
--- a/goeckoh-site/demo.html
+++ b/goeckoh-site/demo.html
@@ -1307,7 +1307,6 @@
 'use strict';
 
 /* ── Constants ─────────────────────────────────────────────── */
-const SR16     = 16000;
 const ORDER    = 12;
 const FRAME    = 512;
 const ALPHA    = 0.15;
@@ -1757,16 +1756,18 @@ function drawLoop() {
   let f0 = 0;
   if (voiced) f0 = estimateF0(timeBuf, audioCtx.sampleRate);
 
-  /* LPC formants (16 kHz decimated) */
+  /* LPC formants (nominally ~16 kHz decimated — actually audioCtx.sampleRate / 3,
+     since browsers don't guarantee the 48000 requested at context creation) */
   let f1 = 0, f2 = 0, f3 = 0, hnr = 0;
   if (voiced) {
+    const decSR = audioCtx.sampleRate / 3;
     const dec  = decimate3(timeBuf);
     const lpc  = levDur(dec.slice(0, FRAME), ORDER);
-    const fmts = formantPeaks(lpc, ORDER, SR16);
+    const fmts = formantPeaks(lpc, ORDER, decSR);
     f1  = fmts[0] || 0;
     f2  = fmts[1] || 0;
     f3  = fmts[2] || 0;
-    hnr = estimateHNR(dec, SR16, f0);
+    hnr = estimateHNR(dec, decSR, f0);
   }
 
   if (voiced) {


### PR DESCRIPTION
## Summary
Follow-up to #43 after a "the demo isn't right" report — audited the whole site to check for anything else wrong.

Found the same class of bug in a second place: the demo's on-screen vowel-space plot and F1/F2/F3/HNR readout (shown during normal, non-Hear-It use) hardcoded `SR16 = 16000` as the decimated analysis sample rate, assuming `audioCtx.sampleRate` is always exactly 48000. On any device/browser that negotiates a different real rate, the displayed formant numbers and vowel-space dot position would be systematically wrong.

Fixed to compute the decimated rate from the actual `audioCtx.sampleRate` at read time — same fix shape as #43, applied to the other analysis path.

## Site audit
Crawled all 11 HTML pages headless: all load with status 200, zero console/page errors, except one orphaned page (`observatory.html`, missing a THREE.js include) that isn't linked from anywhere in the live site — flagging it but not fixing it here since it's unreachable from any real user flow.

## Test plan
- [x] Playwright end-to-end with a fake audio device: demo starts, Hear-The-Correction activates, worklet runs, clean teardown, zero console/page errors
- [x] Full-site crawl confirming no other pages regressed


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Bug Fixes:
- Fix incorrect formant and HNR display in the demo when the browser negotiates a non-48 kHz audio sample rate by computing the decimated rate from the real audio context sample rate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formant and harmonic-to-noise analysis across browsers by adapting calculations to the audio system’s actual sample rate.
  * Increased accuracy when the browser uses a sample rate different from the requested setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->