### PR TITLE
Add research.html to sitemap.xml

### DIFF
--- a/goeckoh-site/sitemap.xml
+++ b/goeckoh-site/sitemap.xml
@@ -15,4 +15,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
+  <url>
+    <loc>https://goeckoh.com/research.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
research.html has strong, specific content (corollary discharge, N1 suppression, DIVA model, formant acoustics) that was missing from the sitemap alongside home/demo/download.

## Summary by Sourcery

New Features:
- Expose research.html as a sitemap entry with its own crawl frequency and priority.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Research page to the site map.
  * Configured it for monthly updates with a priority of 0.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->