### PR TITLE
Add a full standalone For Families page

### DIFF
--- a/goeckoh-site/families.html
+++ b/goeckoh-site/families.html
@@ -1,0 +1,402 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="icon" type="image/png" href="images/logo-light.png">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>For Families — What Using Goeckoh Actually Looks Like</title>
+  <meta name="description" content="A full, honest walkthrough for parents and caregivers: what a day with Goeckoh actually looks like, how guardian monitoring works, what it's designed for, and what to realistically expect.">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="For Families — What Using Goeckoh Actually Looks Like">
+  <meta property="og:description" content="What a day with Goeckoh actually looks like, how guardian monitoring works, and what to realistically expect — written for parents, not marketing copy.">
+  <meta property="og:image" content="https://goeckoh.com/images/logo-light.png">
+  <meta property="og:url" content="https://goeckoh.com/families.html">
+  <meta property="og:site_name" content="Goeckoh">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="For Families — What Using Goeckoh Actually Looks Like">
+  <meta name="twitter:description" content="What a day with Goeckoh actually looks like, how guardian monitoring works, and what to realistically expect.">
+  <meta name="twitter:image" content="https://goeckoh.com/images/logo-light.png">
+  <link rel="canonical" href="https://goeckoh.com/families.html">
+  <link rel="stylesheet" href="goeckoh-shared.css">
+  <style>
+    :root {
+      --gk-bg:        #F7F5F0;
+      --gk-bg-card:   #FFFFFF;
+      --gk-bg-raised: #EDF1F7;
+      --gk-bg-input:  #EEF0F5;
+      --gk-primary:   #2558D9;
+      --gk-teal:      #2A8C7A;
+      --gk-amber:     #C97C1A;
+      --gk-amber-dark: #B8622C;
+      --gk-amber-light: #D98A4E;
+      --gk-red:       #C94040;
+      --gk-green:     #2A8C7A;
+      --gk-blue:      #2558D9;
+      --gk-violet:    #6B5FD8;
+      --gk-text:      #1A2F4B;
+      --gk-text-2:    #4B6280;
+      --gk-muted:     #8098B5;
+      --gk-border:    rgba(26,47,75,0.10);
+      --gk-border-2:  rgba(26,47,75,0.17);
+    }
+    .gk-nav { background: rgba(247,245,240,0.97) !important; border-bottom-color: rgba(26,47,75,0.10) !important; }
+    .gk-nav-cta { color: #fff !important; }
+    .gk-nav-links.gk-open { background: #fff !important; border-bottom-color: rgba(26,47,75,0.10) !important; }
+    .gk-nav-link.active { color: var(--gk-primary) !important; background: rgba(37,88,217,0.08) !important; }
+
+    *, *::before, *::after { margin:0; padding:0; box-sizing:border-box; }
+    html { scroll-behavior:smooth; }
+    body { font-family:var(--gk-font); background:var(--gk-bg); color:var(--gk-text); overflow-x:hidden; }
+
+    .rp-hero { padding: calc(var(--gk-nav-h) + 4rem) 0 3rem; }
+    .rp-eyebrow { font-size:0.68rem; font-weight:700; letter-spacing:0.2em; text-transform:uppercase; color:var(--gk-teal); margin-bottom:1rem; display:block; }
+    .rp-title { font-size:clamp(2rem,4.5vw,3.2rem); font-weight:900; letter-spacing:-0.03em; line-height:1.12; color:var(--gk-text); margin-bottom:1.25rem; max-width:820px; }
+    .rp-intro { font-size:1.05rem; color:var(--gk-text-2); line-height:1.85; max-width:740px; margin-bottom:1.25rem; }
+    .rp-intro strong { color: var(--gk-text); }
+    .rp-honesty {
+      background:#fff; border:1px solid var(--gk-border); border-left:3px solid var(--gk-primary);
+      border-radius:12px; padding:1.4rem 1.6rem; max-width:740px; margin-top:1.5rem;
+      font-size:0.9rem; color:var(--gk-text-2); line-height:1.8;
+    }
+    .rp-honesty strong { color: var(--gk-text); }
+
+    .rp-toc { background:#fff; border:1px solid var(--gk-border); border-radius:16px; padding:1.75rem 2rem; margin-top:2.5rem; max-width:740px; }
+    .rp-toc-label { font-size:0.68rem; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; color:var(--gk-muted); margin-bottom:1rem; display:block; }
+    .rp-toc ol { list-style:none; counter-reset:rp; display:flex; flex-direction:column; gap:0.65rem; }
+    .rp-toc li { counter-increment:rp; }
+    .rp-toc a { display:flex; align-items:baseline; gap:0.75rem; text-decoration:none; color:var(--gk-text); font-size:0.93rem; font-weight:600; transition:color 0.15s; }
+    .rp-toc a:hover { color:var(--gk-primary); }
+    .rp-toc a::before { content: counter(rp); font-family:var(--gk-mono); font-size:0.78rem; font-weight:700; color:var(--gk-primary); flex-shrink:0; width:1.4rem; }
+
+    .rp-section { padding:4.5rem 0; border-top:1px solid var(--gk-border); }
+    .rp-section:nth-child(odd) { background:#fff; }
+    .rp-tag { display:inline-block; font-size:0.66rem; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; padding:0.3rem 0.8rem; border-radius:999px; margin-bottom:1.25rem; }
+    .rp-tag.blue   { color:var(--gk-primary); background:rgba(37,88,217,0.08); }
+    .rp-tag.teal   { color:var(--gk-teal); background:rgba(42,140,122,0.08); }
+    .rp-tag.amber  { color:var(--gk-amber); background:rgba(201,124,26,0.1); }
+    .rp-tag.violet { color:var(--gk-violet); background:rgba(107,95,216,0.08); }
+    .rp-h2 { font-size:clamp(1.5rem,3vw,2.1rem); font-weight:800; letter-spacing:-0.02em; color:var(--gk-text); margin-bottom:0.5rem; max-width:760px; }
+    .rp-h2-sub { font-size:1rem; color:var(--gk-text-2); margin-bottom:2rem; max-width:700px; }
+    .rp-body { max-width:760px; }
+    .rp-body p { font-size:0.98rem; color:var(--gk-text-2); line-height:1.9; margin-bottom:1.3rem; }
+    .rp-body p:last-child { margin-bottom:0; }
+    .rp-body h4 { font-size:0.98rem; font-weight:700; color:var(--gk-text); margin:1.75rem 0 0.6rem; }
+    .rp-body strong { color: var(--gk-text); }
+    .rp-goeckoh { background:var(--gk-bg-raised); border-radius:14px; padding:1.5rem 1.75rem; margin:1.75rem 0; font-size:0.93rem; color:var(--gk-text-2); line-height:1.85; max-width:760px; }
+    .rp-goeckoh strong { color:var(--gk-primary); }
+
+    /* Day-in-the-life timeline */
+    .fp-timeline { max-width:760px; display:flex; flex-direction:column; gap:0; margin-top:0.5rem; }
+    .fp-tl-item { display:grid; grid-template-columns:90px 1fr; gap:1.5rem; padding:1.5rem 0; border-bottom:1px solid var(--gk-border); }
+    .fp-tl-item:last-child { border-bottom:none; }
+    .fp-tl-time { font-family:var(--gk-mono); font-size:0.8rem; font-weight:700; color:var(--gk-primary); padding-top:0.15rem; }
+    .fp-tl-title { font-size:0.98rem; font-weight:700; color:var(--gk-text); margin-bottom:0.4rem; }
+    .fp-tl-body { font-size:0.88rem; color:var(--gk-text-2); line-height:1.8; }
+
+    /* Setup steps */
+    .fp-steps { max-width:760px; display:flex; flex-direction:column; gap:1.25rem; margin-top:0.5rem; }
+    .fp-step { display:grid; grid-template-columns:44px 1fr; gap:1.25rem; }
+    .fp-step-num {
+      width:44px; height:44px; border-radius:50%; background:rgba(37,88,217,0.08);
+      border:1.5px solid rgba(37,88,217,0.22); color:var(--gk-primary); font-weight:800;
+      font-family:var(--gk-mono); display:flex; align-items:center; justify-content:center; flex-shrink:0;
+    }
+    .fp-step-title { font-size:0.95rem; font-weight:700; color:var(--gk-text); margin-bottom:0.35rem; }
+    .fp-step-body { font-size:0.88rem; color:var(--gk-text-2); line-height:1.8; }
+
+    /* Comfort/safety grid */
+    .fp-safety-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:1.25rem; max-width:760px; margin-top:0.5rem; }
+    .fp-safety-item { background:var(--gk-bg-raised); border-radius:12px; padding:1.4rem 1.5rem; }
+    .fp-safety-item h4 { font-size:0.9rem; font-weight:700; color:var(--gk-text); margin-bottom:0.5rem; }
+    .fp-safety-item p { font-size:0.83rem; color:var(--gk-text-2); line-height:1.75; }
+
+    .rp-refs { max-width:760px; margin-top:2.25rem; padding-top:1.75rem; border-top:1px solid var(--gk-border); }
+    .rp-refs-label { font-size:0.68rem; font-weight:700; letter-spacing:0.12em; text-transform:uppercase; color:var(--gk-muted); margin-bottom:0.9rem; display:block; }
+
+    .rp-cta { background:linear-gradient(135deg, #1A2F4B 0%, #1E3D5A 50%, #163547 100%); color:#fff; text-align:center; }
+    .rp-cta h2 { font-size:clamp(1.6rem,3vw,2.2rem); font-weight:800; margin-bottom:1rem; color:#fff; }
+    .rp-cta p { font-size:1rem; color:rgba(255,255,255,0.75); line-height:1.8; max-width:560px; margin:0 auto 1.75rem; }
+  </style>
+</head>
+<body>
+
+<nav class="gk-nav">
+  <a href="index.html" class="gk-nav-brand">
+    <img src="images/logo-light.png" alt="Goeckoh" class="gk-nav-logo">
+    <div>
+      <div class="gk-nav-brand-name">GOECK<span>OH</span></div>
+      <div class="gk-nav-brand-sub">Go Echo</div>
+    </div>
+  </a>
+  <div class="gk-nav-links" id="gkNav">
+    <a href="science.html" class="gk-nav-link">The Science</a>
+    <a href="research.html" class="gk-nav-link">Research</a>
+    <a href="families.html" class="gk-nav-link active">For Families</a>
+    <a href="index.html#clinicians" class="gk-nav-link">For Clinicians</a>
+    <a href="index.html#pricing" class="gk-nav-link">Pricing</a>
+    <a href="demo.html" class="gk-nav-link">Try the Demo</a>
+  </div>
+  <a href="download.html" class="gk-nav-cta">Get Early Access</a>
+  <button class="gk-nav-toggle" aria-label="Menu" aria-controls="gkNav" aria-expanded="false"
+    onclick="const nav=document.getElementById('gkNav'); this.setAttribute('aria-expanded', nav.classList.toggle('gk-open'))">☰</button>
+</nav>
+
+<!-- HERO -->
+<section class="rp-hero">
+  <div class="gk-container">
+    <span class="rp-eyebrow">For Families</span>
+    <h1 class="rp-title">What using Goeckoh actually looks like, day to day.</h1>
+    <p class="rp-intro">
+      Not a feature list — a walkthrough. What a normal day looks like, exactly how you check
+      in from your own phone, what setup actually involves, what it's realistic to expect, and
+      the specific safety questions parents ask before they say yes. If you want the
+      neuroscience behind why any of this works, that's on the
+      <a href="science.html" style="color:var(--gk-primary)">Science</a> and
+      <a href="research.html" style="color:var(--gk-primary)">Research</a> pages — this page is
+      about what it's like to actually live with.
+    </p>
+  </div>
+</section>
+
+<section style="padding-bottom:2rem">
+  <div class="gk-container">
+    <div class="rp-toc">
+      <span class="rp-toc-label">Five things to know before you start</span>
+      <ol>
+        <li><a href="#day-in-the-life">What a normal day actually looks like</a></li>
+        <li><a href="#getting-started">Getting started — the actual steps</a></li>
+        <li><a href="#guardian-monitoring">How guardian monitoring really works</a></li>
+        <li><a href="#comfort-safety">Comfort, safety, and the questions parents actually ask</a></li>
+        <li><a href="#realistic-expectations">What's realistic to expect</a></li>
+      </ol>
+    </div>
+  </div>
+</section>
+
+<!-- 1. DAY IN THE LIFE -->
+<section class="rp-section" id="day-in-the-life">
+  <div class="gk-container">
+    <span class="rp-tag teal">01 · A Normal Day</span>
+    <h2 class="rp-h2">What a normal day actually looks like</h2>
+    <p class="rp-h2-sub">No clinic visits, no scheduled sessions — it works whenever your child is speaking.</p>
+    <div class="fp-timeline">
+      <div class="fp-tl-item">
+        <div class="fp-tl-time">Morning</div>
+        <div>
+          <div class="fp-tl-title">Earbuds go in like any other day</div>
+          <div class="fp-tl-body">Any Bluetooth earbuds with a mic — the ones already in the house work. Open Goeckoh in the browser or the installed app, tap the correction profile that matches your child, and the phone goes in a pocket or bag. That's the entire startup routine.</div>
+        </div>
+      </div>
+      <div class="fp-tl-item">
+        <div class="fp-tl-time">Throughout the day</div>
+        <div>
+          <div class="fp-tl-title">Correction happens during real conversation — not a drill</div>
+          <div class="fp-tl-body">At school, at the grocery store, at the dinner table — anywhere your child speaks with the earbuds in, the correction is running. There's no "session" to schedule or complete. It's present during the actual moments understanding matters, not a 30-minute block set aside for practice.</div>
+        </div>
+      </div>
+      <div class="fp-tl-item">
+        <div class="fp-tl-time">Any time you want</div>
+        <div>
+          <div class="fp-tl-title">You check in from your own device</div>
+          <div class="fp-tl-body">Open the guardian view on your own phone or laptop, enter the session code, and see live acoustic data from your child's session in real time — from a separate room, a separate building, or across town. See "How guardian monitoring really works," below, for exactly what that connection is and isn't.</div>
+        </div>
+      </div>
+      <div class="fp-tl-item">
+        <div class="fp-tl-time">End of day</div>
+        <div>
+          <div class="fp-tl-title">Session history stays on the device that made it</div>
+          <div class="fp-tl-body">Structured progress data — phonological targets, fluency events — is stored locally in the browser on your child's own device. There's no account dashboard on our servers accumulating a history of your child's voice; the record lives where the session happened.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- 2. GETTING STARTED -->
+<section class="rp-section" id="getting-started">
+  <div class="gk-container">
+    <span class="rp-tag blue">02 · Setup</span>
+    <h2 class="rp-h2">Getting started — the actual steps</h2>
+    <p class="rp-h2-sub">From signing up to your child's first corrected conversation.</p>
+    <div class="fp-steps">
+      <div class="fp-step">
+        <div class="fp-step-num">1</div>
+        <div>
+          <div class="fp-step-title">Start early access and get a license key</div>
+          <div class="fp-step-body">Sign up on the <a href="download.html" style="color:var(--gk-primary)">early access page</a>. Your license key arrives by email immediately — it's what unlocks the app on your child's device and any additional devices under your plan.</div>
+        </div>
+      </div>
+      <div class="fp-step">
+        <div class="fp-step-num">2</div>
+        <div>
+          <div class="fp-step-title">Open Goeckoh on your child's device</div>
+          <div class="fp-step-body">It runs directly in Chrome or Safari — no install required — or as a native app on desktop, Windows, Linux, or Android if you prefer one. Enter the license key once; it stays activated on that device.</div>
+        </div>
+      </div>
+      <div class="fp-step">
+        <div class="fp-step-num">3</div>
+        <div>
+          <div class="fp-step-title">Pick a correction profile</div>
+          <div class="fp-step-body">Choose the profile that matches what you're addressing — ASD-related speech patterns, dysarthria, apraxia, or post-stroke/TBI speech changes. This calibrates which vowel targets the correction engine uses; you can change it any time.</div>
+        </div>
+      </div>
+      <div class="fp-step">
+        <div class="fp-step-num">4</div>
+        <div>
+          <div class="fp-step-title">Connect your own device as a guardian monitor</div>
+          <div class="fp-step-body">On your child's device, generate a session code. Enter that same code on your own phone or laptop's guardian view. You're now connected for that session — see below for exactly what that connection carries.</div>
+        </div>
+      </div>
+      <div class="fp-step">
+        <div class="fp-step-num">5</div>
+        <div>
+          <div class="fp-step-title">Put the earbuds on and go about the day</div>
+          <div class="fp-step-body">That's it. No calibration recording, no waiting period. Correction begins the moment your child starts speaking with the earbuds in.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- 3. GUARDIAN MONITORING -->
+<section class="rp-section" id="guardian-monitoring">
+  <div class="gk-container">
+    <span class="rp-tag violet">03 · Guardian Monitoring</span>
+    <h2 class="rp-h2">How guardian monitoring really works</h2>
+    <p class="rp-h2-sub">The specific mechanism — not a vague "you can check in" promise.</p>
+    <div class="rp-body">
+      <p>
+        Each session, your child's device generates a one-time session code — a short string
+        of characters, unique to that session. Enter that same code on your own device's
+        guardian view, and the two devices open a direct, live connection to each other for
+        as long as that session runs.
+      </p>
+      <p>
+        What travels over that connection is <strong>structured metric data only</strong> —
+        the same kind of acoustic readout shown on the child's own screen: formant positions,
+        voice quality measures, fluency events. It is never raw audio. Your child's voice
+        itself never leaves their device, to your device or anywhere else — the correction
+        engine and microphone stay local to the device that's actually being used; only the
+        derived numbers describing what's happening get relayed to you, live.
+      </p>
+      <p>
+        The relay itself does not keep a copy of anything that passes through it. It exists
+        only to forward data from your child's active session to whichever guardian devices
+        are currently connected with the matching code — the moment the session ends, or
+        either device disconnects, there's nothing left on our servers from that connection.
+        If you close the guardian view and reopen it later, you're not resuming a stored
+        history from the server; each session's live view exists only while that session is
+        actually running.
+      </p>
+      <div class="rp-goeckoh">
+        <strong>What you'll actually see:</strong> the same real-time formant, voice-quality,
+        and fluency readout your child's own device shows, updating live as they speak.
+        What you won't see or hear: their raw voice audio, a recording, or a stored history on
+        our end — session history that persists across time lives only in local storage on
+        your child's own device, the same as described in the
+        <a href="science.html#on-device" style="color:var(--gk-primary)">On-Device Architecture</a>
+        section of the Science page.
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- 4. COMFORT & SAFETY -->
+<section class="rp-section" id="comfort-safety">
+  <div class="gk-container">
+    <span class="rp-tag amber">04 · Comfort &amp; Safety</span>
+    <h2 class="rp-h2">Comfort, safety, and the questions parents actually ask</h2>
+    <p class="rp-h2-sub">Answered directly, not deflected into a generic FAQ.</p>
+    <div class="fp-safety-grid">
+      <div class="fp-safety-item">
+        <h4>Does my child have to wear earbuds all day?</h4>
+        <p>No. Correction only happens while the earbuds are in and the app is active. There's no requirement to keep them in for a set number of hours — many families start with short, comfortable stretches and extend from there as the child adjusts to having something in their ear.</p>
+      </div>
+      <div class="fp-safety-item">
+        <h4>Is the volume safe for a child's ears?</h4>
+        <p>The corrected signal plays back at a volume you control, comparable to a normal phone call through earbuds — not amplified beyond a comfortable listening level. There's no electrical contact with the ear or body anywhere in the design; it's audio in, audio out.</p>
+      </div>
+      <div class="fp-safety-item">
+        <h4>Will my child still sound like themselves?</h4>
+        <p>Yes. The correction shapes formant structure only — pitch, speaking rate, and overall voice quality are untouched. It's not a synthetic voice and it's not a replacement voice; see "What Formant Correction Actually Changes" on the Science page for the exact acoustic line being drawn.</p>
+      </div>
+      <div class="fp-safety-item">
+        <h4>What if they resist wearing earbuds at first?</h4>
+        <p>That's common, especially for children with sensory sensitivities. There's no harm in introducing them gradually — a few minutes at a time, during a preferred activity — since the correction only needs to be present during the moments you choose to use it, not continuously.</p>
+      </div>
+      <div class="fp-safety-item">
+        <h4>Does this replace speech therapy?</h4>
+        <p>No — it's built to supplement it. Many families use it alongside an existing speech-language pathologist, and clinicians can review the same structured session data (see the For Clinicians page). It's designed to extend the moments a therapy session can't reach, not to replace clinical care.</p>
+      </div>
+      <div class="fp-safety-item">
+        <h4>What happens if we stop using it?</h4>
+        <p>Nothing is lost or locked away — session history stays in your child's own browser storage regardless of subscription status, and there's no dependency created; Goeckoh corrects feedback in the moment, it doesn't replace any skill your child already has.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- 5. REALISTIC EXPECTATIONS -->
+<section class="rp-section" id="realistic-expectations">
+  <div class="gk-container">
+    <span class="rp-tag teal">05 · Realistic Expectations</span>
+    <h2 class="rp-h2">What's realistic to expect</h2>
+    <p class="rp-h2-sub">Said plainly, because a health product that oversells itself isn't one you should trust.</p>
+    <div class="rp-body">
+      <p>
+        Goeckoh gives the brain a more accurate, better-timed version of its own auditory
+        feedback — that's the entire mechanism, laid out in full on the
+        <a href="science.html" style="color:var(--gk-primary)">Science</a> and
+        <a href="research.html" style="color:var(--gk-primary)">Research</a> pages. What that
+        produces, in practice, varies by person: some families notice a difference in how
+        often they need to ask their child to repeat themselves within the first weeks; for
+        others, especially where speech differences are longstanding or severe, change is
+        slower and more incremental. Speech motor learning is real but it isn't instant, and
+        no single tool — corrected feedback included — is a substitute for the individualized
+        judgment of a speech-language pathologist who knows your child.
+      </p>
+      <p>
+        What we can say with confidence is the mechanism itself: real-time, corrected auditory
+        feedback delivered inside the biological window where the brain can use it is a
+        legitimate, peer-reviewed basis for motor learning. What we won't say is a specific
+        timeline or outcome for your child, because no honest product can promise that in
+        advance.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- CLOSING CTA -->
+<section class="rp-cta">
+  <div class="gk-container">
+    <h2>Ready to see it with your own child's voice?</h2>
+    <p>
+      Try the free demo first — no signup, no commitment — or start early access today if
+      you're ready to begin.
+    </p>
+    <div style="display:flex; gap:0.85rem; justify-content:center; flex-wrap:wrap">
+      <a href="demo.html" class="gk-btn gk-btn-teal">Try the Demo →</a>
+      <a href="download.html" class="gk-btn gk-btn-secondary" style="color:#fff;border-color:rgba(255,255,255,0.3)">Get Early Access →</a>
+    </div>
+  </div>
+</section>
+
+<footer class="gk-footer gk-container">
+  <div class="gk-footer-brand">GOECK<span>OH</span> — Go Echo</div>
+  <div class="gk-footer-links">
+    <a href="index.html">Home</a>
+    <a href="science.html">Science</a>
+    <a href="research.html">Research</a>
+    <a href="families.html">For Families</a>
+    <a href="index.html#pricing">Pricing</a>
+    <a href="demo.html">Demo</a>
+    <a href="mailto:care@goeckoh.com">Contact</a>
+  </div>
+  <div class="gk-footer-copy">© <span id="yr"></span> Goeckoh. All rights reserved.</div>
+</footer>
+
+<script>
+  document.getElementById('yr').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>

--- a/goeckoh-site/index.html
+++ b/goeckoh-site/index.html
@@ -518,7 +518,7 @@
   <div class="gk-nav-links" id="gkNav">
     <a href="science.html" class="gk-nav-link">The Science</a>
     <a href="research.html" class="gk-nav-link">Research</a>
-    <a href="#families"   class="gk-nav-link">For Families</a>
+    <a href="families.html" class="gk-nav-link">For Families</a>
     <a href="#clinicians" class="gk-nav-link">For Clinicians</a>
     <a href="#pricing"    class="gk-nav-link">Pricing</a>
     <a href="demo.html"   class="gk-nav-link">Try the Demo</a>
@@ -1008,6 +1008,7 @@
           <li>No synthetic voice — your child sounds like themselves</li>
           <li>Your child's data never leaves their device</li>
         </ul>
+        <a href="families.html" class="gk-btn gk-btn-secondary" style="margin-top:1.5rem">See a Full Day, Setup &amp; Guardian Monitoring →</a>
       </div>
       <div class="audience-card">
         <span class="aud-icon">🩺</span>
@@ -1289,6 +1290,7 @@
     <a href="index.html">Home</a>
     <a href="science.html">Science</a>
     <a href="research.html">Research</a>
+    <a href="families.html">For Families</a>
     <a href="#pricing">Pricing</a>
     <a href="demo.html">Demo</a>
     <a href="mailto:care@goeckoh.com">Contact</a>

--- a/goeckoh-site/research.html
+++ b/goeckoh-site/research.html
@@ -125,7 +125,7 @@
   <div class="gk-nav-links" id="gkNav">
     <a href="index.html#science" class="gk-nav-link">The Science</a>
     <a href="research.html" class="gk-nav-link active">Research</a>
-    <a href="index.html#families" class="gk-nav-link">For Families</a>
+    <a href="families.html" class="gk-nav-link">For Families</a>
     <a href="index.html#clinicians" class="gk-nav-link">For Clinicians</a>
     <a href="index.html#pricing" class="gk-nav-link">Pricing</a>
     <a href="demo.html" class="gk-nav-link">Try the Demo</a>

--- a/goeckoh-site/science.html
+++ b/goeckoh-site/science.html
@@ -125,7 +125,7 @@
   <div class="gk-nav-links" id="gkNav">
     <a href="science.html" class="gk-nav-link active">The Science</a>
     <a href="research.html" class="gk-nav-link">Research</a>
-    <a href="index.html#families" class="gk-nav-link">For Families</a>
+    <a href="families.html" class="gk-nav-link">For Families</a>
     <a href="index.html#clinicians" class="gk-nav-link">For Clinicians</a>
     <a href="index.html#pricing" class="gk-nav-link">Pricing</a>
     <a href="demo.html" class="gk-nav-link">Try the Demo</a>


### PR DESCRIPTION
## Summary
Third of the five nav sections converted from a homepage anchor into a real page (Research and Science already merged).

Where those two cover evidence and engineering, `families.html` covers what it's actually like to use day to day — aimed at a parent/caregiver deciding whether to trust this with their child:

- A concrete day-in-the-life walkthrough, not a feature list
- The actual setup steps from signup to first corrected conversation
- Exactly how guardian monitoring works mechanically — the session-code relay, that only structured metrics cross it (never raw audio), and that the relay itself stores nothing (matches the real backend implementation in `backend/main.py`'s `/ws/broadcast/{code}` and `/ws/monitor/{code}`)
- Direct answers to the specific comfort/safety questions parents ask (earbud tolerance, volume, "will they still sound like themselves", whether this replaces therapy)
- An honest "realistic expectations" section that doesn't promise a timeline or outcome

Nav/footer updated across `index.html`, `science.html`, and `research.html` from the `#families` anchor to `families.html`. Homepage's audience card now links through to the full page.

## Test plan
- [x] Verified in a headless browser: no console errors, all 5 in-page anchors work, homepage → families.html CTA link works
- [x] Confirmed nav/footer updated from `#families` anchor to `families.html` across all three other standalone pages plus the homepage


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Add a dedicated For Families page explaining day-to-day use, setup, guardian monitoring, comfort/safety, and realistic expectations, and wire it into the site navigation and homepage CTA.

New Features:
- Introduce a standalone families.html page targeted at parents and caregivers with a full day-in-the-life walkthrough and usage details.

Enhancements:
- Update site navigation and footer links across existing pages to point to the new For Families page instead of in-page anchors.
- Add a homepage audience card CTA button linking through to the new For Families page.