### PR TITLE
Add a full standalone For Clinicians page

### DIFF
--- a/goeckoh-site/clinicians.html
+++ b/goeckoh-site/clinicians.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="icon" type="image/png" href="images/logo-light.png">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>For Clinicians — Remote Monitoring, Session Data & Correction Profiles</title>
+  <meta name="description" content="What Goeckoh gives a speech-language pathologist or clinic that clinic time alone can't: live remote monitoring, structured per-utterance session data, condition-specific correction profiles, and how it fits alongside existing therapy protocols.">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="For Clinicians — Remote Monitoring, Session Data & Correction Profiles">
+  <meta property="og:description" content="Live remote monitoring, structured session data, and correction profiles that supplement — not replace — clinical speech therapy.">
+  <meta property="og:image" content="https://goeckoh.com/images/logo-light.png">
+  <meta property="og:url" content="https://goeckoh.com/clinicians.html">
+  <meta property="og:site_name" content="Goeckoh">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="For Clinicians — Remote Monitoring, Session Data & Correction Profiles">
+  <meta name="twitter:description" content="Live remote monitoring, structured session data, and correction profiles that supplement clinical speech therapy.">
+  <meta name="twitter:image" content="https://goeckoh.com/images/logo-light.png">
+  <link rel="canonical" href="https://goeckoh.com/clinicians.html">
+  <link rel="stylesheet" href="goeckoh-shared.css">
+  <style>
+    :root {
+      --gk-bg:        #F7F5F0;
+      --gk-bg-card:   #FFFFFF;
+      --gk-bg-raised: #EDF1F7;
+      --gk-bg-input:  #EEF0F5;
+      --gk-primary:   #2558D9;
+      --gk-teal:      #2A8C7A;
+      --gk-amber:     #C97C1A;
+      --gk-amber-dark: #B8622C;
+      --gk-amber-light: #D98A4E;
+      --gk-red:       #C94040;
+      --gk-green:     #2A8C7A;
+      --gk-blue:      #2558D9;
+      --gk-violet:    #6B5FD8;
+      --gk-text:      #1A2F4B;
+      --gk-text-2:    #4B6280;
+      --gk-muted:     #8098B5;
+      --gk-border:    rgba(26,47,75,0.10);
+      --gk-border-2:  rgba(26,47,75,0.17);
+    }
+    .gk-nav { background: rgba(247,245,240,0.97) !important; border-bottom-color: rgba(26,47,75,0.10) !important; }
+    .gk-nav-cta { color: #fff !important; }
+    .gk-nav-links.gk-open { background: #fff !important; border-bottom-color: rgba(26,47,75,0.10) !important; }
+    .gk-nav-link.active { color: var(--gk-primary) !important; background: rgba(37,88,217,0.08) !important; }
+
+    *, *::before, *::after { margin:0; padding:0; box-sizing:border-box; }
+    html { scroll-behavior:smooth; }
+    body { font-family:var(--gk-font); background:var(--gk-bg); color:var(--gk-text); overflow-x:hidden; }
+
+    .rp-hero { padding: calc(var(--gk-nav-h) + 4rem) 0 3rem; }
+    .rp-eyebrow { font-size:0.68rem; font-weight:700; letter-spacing:0.2em; text-transform:uppercase; color:var(--gk-teal); margin-bottom:1rem; display:block; }
+    .rp-title { font-size:clamp(2rem,4.5vw,3.2rem); font-weight:900; letter-spacing:-0.03em; line-height:1.12; color:var(--gk-text); margin-bottom:1.25rem; max-width:820px; }
+    .rp-intro { font-size:1.05rem; color:var(--gk-text-2); line-height:1.85; max-width:740px; margin-bottom:1.25rem; }
+    .rp-intro strong { color: var(--gk-text); }
+    .rp-honesty {
+      background:#fff; border:1px solid var(--gk-border); border-left:3px solid var(--gk-primary);
+      border-radius:12px; padding:1.4rem 1.6rem; max-width:740px; margin-top:1.5rem;
+      font-size:0.9rem; color:var(--gk-text-2); line-height:1.8;
+    }
+    .rp-honesty strong { color: var(--gk-text); }
+
+    .rp-toc { background:#fff; border:1px solid var(--gk-border); border-radius:16px; padding:1.75rem 2rem; margin-top:2.5rem; max-width:740px; }
+    .rp-toc-label { font-size:0.68rem; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; color:var(--gk-muted); margin-bottom:1rem; display:block; }
+    .rp-toc ol { list-style:none; counter-reset:rp; display:flex; flex-direction:column; gap:0.65rem; }
+    .rp-toc li { counter-increment:rp; }
+    .rp-toc a { display:flex; align-items:baseline; gap:0.75rem; text-decoration:none; color:var(--gk-text); font-size:0.93rem; font-weight:600; transition:color 0.15s; }
+    .rp-toc a:hover { color:var(--gk-primary); }
+    .rp-toc a::before { content: counter(rp); font-family:var(--gk-mono); font-size:0.78rem; font-weight:700; color:var(--gk-primary); flex-shrink:0; width:1.4rem; }
+
+    .rp-section { padding:4.5rem 0; border-top:1px solid var(--gk-border); }
+    .rp-section:nth-child(odd) { background:#fff; }
+    .rp-tag { display:inline-block; font-size:0.66rem; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; padding:0.3rem 0.8rem; border-radius:999px; margin-bottom:1.25rem; }
+    .rp-tag.blue   { color:var(--gk-primary); background:rgba(37,88,217,0.08); }
+    .rp-tag.teal   { color:var(--gk-teal); background:rgba(42,140,122,0.08); }
+    .rp-tag.amber  { color:var(--gk-amber); background:rgba(201,124,26,0.1); }
+    .rp-tag.violet { color:var(--gk-violet); background:rgba(107,95,216,0.08); }
+    .rp-h2 { font-size:clamp(1.5rem,3vw,2.1rem); font-weight:800; letter-spacing:-0.02em; color:var(--gk-text); margin-bottom:0.5rem; max-width:760px; }
+    .rp-h2-sub { font-size:1rem; color:var(--gk-text-2); margin-bottom:2rem; max-width:700px; }
+    .rp-body { max-width:760px; }
+    .rp-body p { font-size:0.98rem; color:var(--gk-text-2); line-height:1.9; margin-bottom:1.3rem; }
+    .rp-body p:last-child { margin-bottom:0; }
+    .rp-body h4 { font-size:0.98rem; font-weight:700; color:var(--gk-text); margin:1.75rem 0 0.6rem; }
+    .rp-body strong { color: var(--gk-text); }
+    .rp-goeckoh { background:var(--gk-bg-raised); border-radius:14px; padding:1.5rem 1.75rem; margin:1.75rem 0; font-size:0.93rem; color:var(--gk-text-2); line-height:1.85; max-width:760px; }
+    .rp-goeckoh strong { color:var(--gk-primary); }
+
+    /* Data field table */
+    .field-table { width:100%; max-width:760px; border-collapse:collapse; margin:1.75rem 0; font-size:0.86rem; }
+    .field-table th, .field-table td { padding:0.9rem 1rem; text-align:left; border-bottom:1px solid var(--gk-border); vertical-align:top; }
+    .field-table th { font-size:0.64rem; font-weight:700; text-transform:uppercase; letter-spacing:0.08em; color:var(--gk-muted); background:var(--gk-bg-raised); }
+    .field-table td:first-child { font-weight:700; color:var(--gk-text); white-space:nowrap; }
+    @media(max-width:640px){ .field-table td:first-child { white-space:normal; } }
+
+    /* Profile cards */
+    .profile-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:1.1rem; max-width:760px; margin-top:0.5rem; }
+    .profile-card { background:var(--gk-bg-raised); border-radius:12px; padding:1.3rem 1.4rem; }
+    .profile-card h4 { font-size:0.88rem; font-weight:700; color:var(--gk-text); margin-bottom:0.4rem; }
+    .profile-card p { font-size:0.8rem; color:var(--gk-text-2); line-height:1.7; }
+
+    .rp-refs { max-width:760px; margin-top:2.25rem; padding-top:1.75rem; border-top:1px solid var(--gk-border); }
+    .rp-refs-label { font-size:0.68rem; font-weight:700; letter-spacing:0.12em; text-transform:uppercase; color:var(--gk-muted); margin-bottom:0.9rem; display:block; }
+
+    .rp-cta { background:linear-gradient(135deg, #1A2F4B 0%, #1E3D5A 50%, #163547 100%); color:#fff; text-align:center; }
+    .rp-cta h2 { font-size:clamp(1.6rem,3vw,2.2rem); font-weight:800; margin-bottom:1rem; color:#fff; }
+    .rp-cta p { font-size:1rem; color:rgba(255,255,255,0.75); line-height:1.8; max-width:560px; margin:0 auto 1.75rem; }
+  </style>
+</head>
+<body>
+
+<nav class="gk-nav">
+  <a href="index.html" class="gk-nav-brand">
+    <img src="images/logo-light.png" alt="Goeckoh" class="gk-nav-logo">
+    <div>
+      <div class="gk-nav-brand-name">GOECK<span>OH</span></div>
+      <div class="gk-nav-brand-sub">Go Echo</div>
+    </div>
+  </a>
+  <div class="gk-nav-links" id="gkNav">
+    <a href="science.html" class="gk-nav-link">The Science</a>
+    <a href="research.html" class="gk-nav-link">Research</a>
+    <a href="families.html" class="gk-nav-link">For Families</a>
+    <a href="clinicians.html" class="gk-nav-link active">For Clinicians</a>
+    <a href="index.html#pricing" class="gk-nav-link">Pricing</a>
+    <a href="demo.html" class="gk-nav-link">Try the Demo</a>
+  </div>
+  <a href="download.html" class="gk-nav-cta">Get Early Access</a>
+  <button class="gk-nav-toggle" aria-label="Menu" aria-controls="gkNav" aria-expanded="false"
+    onclick="const nav=document.getElementById('gkNav'); this.setAttribute('aria-expanded', nav.classList.toggle('gk-open'))">☰</button>
+</nav>
+
+<!-- HERO -->
+<section class="rp-hero">
+  <div class="gk-container">
+    <span class="rp-eyebrow">For Clinicians</span>
+    <h1 class="rp-title">What this gives you that clinic time alone can't.</h1>
+    <p class="rp-intro">
+      Goeckoh is built to supplement clinical speech-language pathology, not replace it. This
+      page is the specific, practical detail a clinician needs to evaluate that claim: exactly
+      what data gets recorded and how, how remote monitoring actually works between sessions,
+      what a correction profile changes, and how to get clinical or district pricing. For the
+      underlying mechanism and evidence, see the
+      <a href="science.html" style="color:var(--gk-primary)">Science</a> and
+      <a href="research.html" style="color:var(--gk-primary)">Research</a> pages.
+    </p>
+  </div>
+</section>
+
+<section style="padding-bottom:2rem">
+  <div class="gk-container">
+    <div class="rp-toc">
+      <span class="rp-toc-label">Four things to know</span>
+      <ol>
+        <li><a href="#remote-monitoring">Live remote monitoring between sessions</a></li>
+        <li><a href="#session-data">Exactly what session data gets recorded</a></li>
+        <li><a href="#correction-profiles">Correction profiles — what they calibrate</a></li>
+        <li><a href="#integration-pricing">Fitting it into your existing protocol, and clinical/district pricing</a></li>
+      </ol>
+    </div>
+  </div>
+</section>
+
+<!-- 1. REMOTE MONITORING -->
+<section class="rp-section" id="remote-monitoring">
+  <div class="gk-container">
+    <span class="rp-tag blue">01 · Remote Monitoring</span>
+    <h2 class="rp-h2">Live remote monitoring between sessions</h2>
+    <p class="rp-h2-sub">The same real-time mechanism a guardian uses, applied to a clinical caseload.</p>
+    <div class="rp-body">
+      <p>
+        A patient's device generates a short-lived session code each time Goeckoh is in use.
+        Enter that code on your own device, and you get a live, direct connection to that
+        session's acoustic readout — formant positions, voice quality measures, and fluency
+        events — updating in real time while the patient is speaking, wherever they actually
+        are: at home, at school, anywhere the correction is running. You are not limited to
+        observing what happens inside a scheduled appointment.
+      </p>
+      <p>
+        The connection is a direct relay between the two devices — the server forwards data to
+        whichever monitoring devices are currently connected with the matching code, and keeps
+        no copy of it. It does not accumulate a server-side archive of patient sessions you
+        query later; each live view exists only while that specific session is running.
+        Structured history that persists across sessions is described in the next section.
+      </p>
+      <div class="rp-goeckoh">
+        <strong>Multi-patient use:</strong> nothing about the relay mechanism limits you to one
+        patient — each patient's device generates its own independent session code, so a
+        clinician managing a caseload can monitor whichever patient's session is currently
+        active by entering that patient's code, one at a time, without cross-contamination
+        between patients' data.
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- 2. SESSION DATA -->
+<section class="rp-section" id="session-data">
+  <div class="gk-container">
+    <span class="rp-tag teal">02 · Session Data</span>
+    <h2 class="rp-h2">Exactly what session data gets recorded</h2>
+    <p class="rp-h2-sub">Structured, countable events — not a subjective summary.</p>
+    <div class="rp-body">
+      <p>
+        Every session logs discrete, operationally defined events, consistent with the
+        Applied Behavior Analysis measurement approach described in full on the
+        <a href="research.html#aba-methodology" style="color:var(--gk-primary)">Research page</a>.
+        The point is the same one ABA measurement always makes: whether a skill is improving
+        should be answerable from data, not from how a session felt.
+      </p>
+      <table class="field-table">
+        <thead><tr><th>Field</th><th>What it captures</th></tr></thead>
+        <tbody>
+          <tr><td>Phonological targets</td><td>Which vowel or consonant productions were attempted, and how closely each landed to its acoustic target for the active correction profile.</td></tr>
+          <tr><td>Fluency events</td><td>Discrete moments — hesitations, self-corrections, successful productions — logged as countable events rather than an overall impression.</td></tr>
+          <tr><td>Voice quality metrics</td><td>Formant positions (F1/F2/F3), harmonics-to-noise ratio, and related acoustic measures per utterance.</td></tr>
+          <tr><td>Co-regulation markers</td><td>Session-level indicators relevant to emotional/behavioral state during the session, where applicable.</td></tr>
+        </tbody>
+      </table>
+      <p>
+        This structured history is stored in the browser's local storage on the patient's own
+        device — the same architecture described in the
+        <a href="science.html#on-device" style="color:var(--gk-primary)">On-Device
+        Architecture</a> section of the Science page. It is available for review on that
+        device across sessions, so a trend across weeks is visible, not just a single session's
+        snapshot — but it is not aggregated into a server-side clinical record you query
+        remotely outside of a live monitoring connection.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- 3. CORRECTION PROFILES -->
+<section class="rp-section" id="correction-profiles">
+  <div class="gk-container">
+    <span class="rp-tag violet">03 · Correction Profiles</span>
+    <h2 class="rp-h2">Correction profiles — what they actually calibrate</h2>
+    <p class="rp-h2-sub">Different conditions distort the vowel space differently. Profiles aren't a cosmetic setting.</p>
+    <div class="rp-body">
+      <p>
+        As explained in the "What Formant Correction Actually Changes" section of the
+        <a href="science.html#formant-correction" style="color:var(--gk-primary)">Science
+        page</a>, the correction engine shifts a speaker's current formant positions toward a
+        target vowel region. A correction profile determines which target region and how
+        strongly to correct toward it — because the acoustic signature of, say, dysarthria
+        following a stroke is not the same as an ASD-associated speech pattern or apraxia, and
+        correcting toward the wrong target would work against the patient rather than for
+        them.
+      </p>
+      <div class="profile-grid">
+        <div class="profile-card">
+          <h4>ASD Voice Profile</h4>
+          <p>Calibrated for speech patterns associated with autism spectrum presentations.</p>
+        </div>
+        <div class="profile-card">
+          <h4>Dysarthria</h4>
+          <p>Targets the centralized, compressed vowel space typical of dysarthric speech following stroke or neurological injury.</p>
+        </div>
+        <div class="profile-card">
+          <h4>Apraxia</h4>
+          <p>Calibrated for the articulatory-planning signature characteristic of apraxia of speech.</p>
+        </div>
+        <div class="profile-card">
+          <h4>Post-TBI</h4>
+          <p>Addresses speech changes following traumatic brain injury, which can present differently from stroke-related dysarthria.</p>
+        </div>
+      </div>
+      <p>
+        Selecting a profile is the patient's or caregiver's action inside the app — it doesn't
+        require clinician configuration to change — but as the clinician of record, you're the
+        one best positioned to advise which profile actually matches the presentation you're
+        treating, and to review the session data (above) to judge whether it's producing the
+        acoustic change you'd expect.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- 4. INTEGRATION & PRICING -->
+<section class="rp-section" id="integration-pricing">
+  <div class="gk-container">
+    <span class="rp-tag amber">04 · Integration &amp; Pricing</span>
+    <h2 class="rp-h2">Fitting it into your existing protocol</h2>
+    <p class="rp-h2-sub">Designed to extend a therapy plan you already own, not compete with it.</p>
+    <div class="rp-body">
+      <p>
+        Goeckoh is not a therapy protocol in itself — it doesn't prescribe a treatment plan or
+        make clinical decisions. It's a real-time correction and structured-measurement tool
+        you can point at a specific acoustic goal you've already identified for a patient, and
+        then review the resulting data alongside whatever standard clinical documentation your
+        practice already uses. Many clinicians use it as the thing that's present in the gaps
+        a weekly session can't reach — a car ride, a classroom, a dinner table — rather than as
+        a replacement for direct clinical contact.
+      </p>
+      <p>
+        On data handling: no voice audio is ever transmitted to or stored on Goeckoh's servers,
+        under any use case described on this page — the architecture is the same on-device
+        design described throughout this site, not a special clinical mode. We're not making a
+        specific regulatory-compliance certification claim here; if your practice or district
+        has a formal compliance review process, we're glad to work through it directly —
+        contact <a href="mailto:care@goeckoh.com" style="color:var(--gk-primary)">care@goeckoh.com</a>.
+      </p>
+      <h4>Clinical and school/district pricing</h4>
+      <p>
+        Standard pricing is $20/month per person. For clinics or school districts managing
+        multiple patients, contact us directly for volume pricing —
+        <a href="mailto:care@goeckoh.com" style="color:var(--gk-primary)">care@goeckoh.com</a>.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- CLOSING CTA -->
+<section class="rp-cta">
+  <div class="gk-container">
+    <h2>See it running on a real voice first.</h2>
+    <p>
+      Try the free demo, or reach out directly to discuss clinical or district pricing for
+      your caseload.
+    </p>
+    <div style="display:flex; gap:0.85rem; justify-content:center; flex-wrap:wrap">
+      <a href="demo.html" class="gk-btn gk-btn-teal">Try the Demo →</a>
+      <a href="mailto:care@goeckoh.com" class="gk-btn gk-btn-secondary" style="color:#fff;border-color:rgba(255,255,255,0.3)">Contact Us →</a>
+    </div>
+  </div>
+</section>
+
+<footer class="gk-footer gk-container">
+  <div class="gk-footer-brand">GOECK<span>OH</span> — Go Echo</div>
+  <div class="gk-footer-links">
+    <a href="index.html">Home</a>
+    <a href="science.html">Science</a>
+    <a href="research.html">Research</a>
+    <a href="families.html">For Families</a>
+    <a href="clinicians.html">For Clinicians</a>
+    <a href="index.html#pricing">Pricing</a>
+    <a href="demo.html">Demo</a>
+    <a href="mailto:care@goeckoh.com">Contact</a>
+  </div>
+  <div class="gk-footer-copy">© <span id="yr"></span> Goeckoh. All rights reserved.</div>
+</footer>
+
+<script>
+  document.getElementById('yr').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>

--- a/goeckoh-site/families.html
+++ b/goeckoh-site/families.html
@@ -132,7 +132,7 @@
     <a href="science.html" class="gk-nav-link">The Science</a>
     <a href="research.html" class="gk-nav-link">Research</a>
     <a href="families.html" class="gk-nav-link active">For Families</a>
-    <a href="index.html#clinicians" class="gk-nav-link">For Clinicians</a>
+    <a href="clinicians.html" class="gk-nav-link">For Clinicians</a>
     <a href="index.html#pricing" class="gk-nav-link">Pricing</a>
     <a href="demo.html" class="gk-nav-link">Try the Demo</a>
   </div>
@@ -326,7 +326,7 @@
       </div>
       <div class="fp-safety-item">
         <h4>Does this replace speech therapy?</h4>
-        <p>No — it's built to supplement it. Many families use it alongside an existing speech-language pathologist, and clinicians can review the same structured session data (see the For Clinicians page). It's designed to extend the moments a therapy session can't reach, not to replace clinical care.</p>
+        <p>No — it's built to supplement it. Many families use it alongside an existing speech-language pathologist, and clinicians can review the same structured session data (see the <a href="clinicians.html" style="color:var(--gk-primary)">For Clinicians</a> page). It's designed to extend the moments a therapy session can't reach, not to replace clinical care.</p>
       </div>
       <div class="fp-safety-item">
         <h4>What happens if we stop using it?</h4>

--- a/goeckoh-site/index.html
+++ b/goeckoh-site/index.html
@@ -519,7 +519,7 @@
     <a href="science.html" class="gk-nav-link">The Science</a>
     <a href="research.html" class="gk-nav-link">Research</a>
     <a href="families.html" class="gk-nav-link">For Families</a>
-    <a href="#clinicians" class="gk-nav-link">For Clinicians</a>
+    <a href="clinicians.html" class="gk-nav-link">For Clinicians</a>
     <a href="#pricing"    class="gk-nav-link">Pricing</a>
     <a href="demo.html"   class="gk-nav-link">Try the Demo</a>
   </div>
@@ -1026,6 +1026,7 @@
           <li>Supplement your existing therapy protocol — not replace it</li>
           <li>ABA-aligned progress tracking built in</li>
         </ul>
+        <a href="clinicians.html" class="gk-btn gk-btn-secondary" style="margin-top:1.5rem">See Session Data, Profiles &amp; Pricing →</a>
       </div>
     </div>
 
@@ -1291,6 +1292,7 @@
     <a href="science.html">Science</a>
     <a href="research.html">Research</a>
     <a href="families.html">For Families</a>
+    <a href="clinicians.html">For Clinicians</a>
     <a href="#pricing">Pricing</a>
     <a href="demo.html">Demo</a>
     <a href="mailto:care@goeckoh.com">Contact</a>

--- a/goeckoh-site/research.html
+++ b/goeckoh-site/research.html
@@ -126,7 +126,7 @@
     <a href="index.html#science" class="gk-nav-link">The Science</a>
     <a href="research.html" class="gk-nav-link active">Research</a>
     <a href="families.html" class="gk-nav-link">For Families</a>
-    <a href="index.html#clinicians" class="gk-nav-link">For Clinicians</a>
+    <a href="clinicians.html" class="gk-nav-link">For Clinicians</a>
     <a href="index.html#pricing" class="gk-nav-link">Pricing</a>
     <a href="demo.html" class="gk-nav-link">Try the Demo</a>
   </div>

--- a/goeckoh-site/science.html
+++ b/goeckoh-site/science.html
@@ -126,7 +126,7 @@
     <a href="science.html" class="gk-nav-link active">The Science</a>
     <a href="research.html" class="gk-nav-link">Research</a>
     <a href="families.html" class="gk-nav-link">For Families</a>
-    <a href="index.html#clinicians" class="gk-nav-link">For Clinicians</a>
+    <a href="clinicians.html" class="gk-nav-link">For Clinicians</a>
     <a href="index.html#pricing" class="gk-nav-link">Pricing</a>
     <a href="demo.html" class="gk-nav-link">Try the Demo</a>
   </div>


### PR DESCRIPTION
## Summary
Fourth of the five nav sections converted from a homepage anchor into a real page (Research, Science, and For Families already merged).

Written for a speech-language pathologist or clinic deciding whether and how to fit this alongside existing care:

- How live remote monitoring works for a clinical caseload — same session-code relay as guardian monitoring, applied per-patient, with no server-side accumulation of patient session data
- A field-by-field table of exactly what session data gets recorded (phonological targets, fluency events, voice quality metrics, co-regulation markers) and where it's stored
- What a correction profile actually calibrates and why the four profiles (ASD, dysarthria, apraxia, post-TBI) target different acoustic signatures
- How it's meant to fit into an existing therapy protocol, honest language on data handling that doesn't claim a specific regulatory certification we haven't gone through, and clinical/district pricing

Nav/footer updated across `index.html`, `science.html`, `research.html`, and `families.html` from the `#clinicians` anchor to `clinicians.html`. Homepage's clinician audience card links through to the full page, and the families FAQ answer that mentions the clinicians page now actually links to it.

## Test plan
- [x] Verified in a headless browser: no console errors, all 4 in-page anchors work, homepage → clinicians.html CTA link works
- [x] Confirmed nav/footer updated from `#clinicians` anchor to `clinicians.html` across all pages


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Introduce a standalone For Clinicians page and wire site navigation and content to link to it instead of the previous homepage anchor.

New Features:
- Add a dedicated clinicians.html page describing remote monitoring, recorded session data fields, correction profiles, clinical integration, and pricing for speech-language pathologists and clinics.

Enhancements:
- Update top navigation and footer across existing pages to link to clinicians.html rather than the #clinicians homepage anchor.
- Add a homepage call-to-action button from the clinician audience card through to the new clinicians page.
- Convert the families FAQ reference to the clinicians page into a direct hyperlink to clinicians.html.