### PR TITLE
Add a full standalone Pricing page — the last of the five nav sections

### DIFF
--- a/goeckoh-site/clinicians.html
+++ b/goeckoh-site/clinicians.html
@@ -121,7 +121,7 @@
     <a href="research.html" class="gk-nav-link">Research</a>
     <a href="families.html" class="gk-nav-link">For Families</a>
     <a href="clinicians.html" class="gk-nav-link active">For Clinicians</a>
-    <a href="index.html#pricing" class="gk-nav-link">Pricing</a>
+    <a href="pricing.html" class="gk-nav-link">Pricing</a>
     <a href="demo.html" class="gk-nav-link">Try the Demo</a>
   </div>
   <a href="download.html" class="gk-nav-cta">Get Early Access</a>
@@ -332,7 +332,7 @@
     <a href="research.html">Research</a>
     <a href="families.html">For Families</a>
     <a href="clinicians.html">For Clinicians</a>
-    <a href="index.html#pricing">Pricing</a>
+    <a href="pricing.html">Pricing</a>
     <a href="demo.html">Demo</a>
     <a href="mailto:care@goeckoh.com">Contact</a>
   </div>

--- a/goeckoh-site/families.html
+++ b/goeckoh-site/families.html
@@ -133,7 +133,7 @@
     <a href="research.html" class="gk-nav-link">Research</a>
     <a href="families.html" class="gk-nav-link active">For Families</a>
     <a href="clinicians.html" class="gk-nav-link">For Clinicians</a>
-    <a href="index.html#pricing" class="gk-nav-link">Pricing</a>
+    <a href="pricing.html" class="gk-nav-link">Pricing</a>
     <a href="demo.html" class="gk-nav-link">Try the Demo</a>
   </div>
   <a href="download.html" class="gk-nav-cta">Get Early Access</a>
@@ -388,7 +388,7 @@
     <a href="science.html">Science</a>
     <a href="research.html">Research</a>
     <a href="families.html">For Families</a>
-    <a href="index.html#pricing">Pricing</a>
+    <a href="pricing.html">Pricing</a>
     <a href="demo.html">Demo</a>
     <a href="mailto:care@goeckoh.com">Contact</a>
   </div>

--- a/goeckoh-site/index.html
+++ b/goeckoh-site/index.html
@@ -520,7 +520,7 @@
     <a href="research.html" class="gk-nav-link">Research</a>
     <a href="families.html" class="gk-nav-link">For Families</a>
     <a href="clinicians.html" class="gk-nav-link">For Clinicians</a>
-    <a href="#pricing"    class="gk-nav-link">Pricing</a>
+    <a href="pricing.html" class="gk-nav-link">Pricing</a>
     <a href="demo.html"   class="gk-nav-link">Try the Demo</a>
   </div>
   <a href="download.html" class="gk-nav-cta">Get Early Access</a>
@@ -1134,6 +1134,9 @@
       </a>
       <p class="price-note">Clinical and school/district pricing available — <a href="mailto:care@goeckoh.com" style="color:var(--gk-primary);text-decoration:none">contact us</a></p>
     </div>
+    <div style="text-align:center;margin-top:1.75rem">
+      <a href="pricing.html" style="color:var(--gk-primary);font-size:0.87rem;font-weight:700;text-decoration:none">See Full Comparison &amp; Billing FAQ →</a>
+    </div>
   </div>
 </section>
 
@@ -1293,7 +1296,7 @@
     <a href="research.html">Research</a>
     <a href="families.html">For Families</a>
     <a href="clinicians.html">For Clinicians</a>
-    <a href="#pricing">Pricing</a>
+    <a href="pricing.html">Pricing</a>
     <a href="demo.html">Demo</a>
     <a href="mailto:care@goeckoh.com">Contact</a>
   </div>

--- a/goeckoh-site/pricing.html
+++ b/goeckoh-site/pricing.html
@@ -1,0 +1,414 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="icon" type="image/png" href="images/logo-light.png">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pricing — $20/Month, One Plan, No Surprises</title>
+  <meta name="description" content="Goeckoh is $20 per person per month, cancel any time — what's included, how it compares to alternatives that cost thousands, clinical and district pricing, and the billing questions people actually ask.">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Pricing — $20/Month, One Plan, No Surprises">
+  <meta property="og:description" content="$20 per person per month, cancel any time. What's included, how it compares to alternatives, and clinical/district pricing.">
+  <meta property="og:image" content="https://goeckoh.com/images/logo-light.png">
+  <meta property="og:url" content="https://goeckoh.com/pricing.html">
+  <meta property="og:site_name" content="Goeckoh">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Pricing — $20/Month, One Plan, No Surprises">
+  <meta name="twitter:description" content="$20 per person per month, cancel any time. What's included and how it compares to alternatives.">
+  <meta name="twitter:image" content="https://goeckoh.com/images/logo-light.png">
+  <link rel="canonical" href="https://goeckoh.com/pricing.html">
+  <link rel="stylesheet" href="goeckoh-shared.css">
+  <style>
+    :root {
+      --gk-bg:        #F7F5F0;
+      --gk-bg-card:   #FFFFFF;
+      --gk-bg-raised: #EDF1F7;
+      --gk-bg-input:  #EEF0F5;
+      --gk-primary:   #2558D9;
+      --gk-teal:      #2A8C7A;
+      --gk-amber:     #C97C1A;
+      --gk-amber-dark: #B8622C;
+      --gk-amber-light: #D98A4E;
+      --gk-red:       #C94040;
+      --gk-green:     #2A8C7A;
+      --gk-blue:      #2558D9;
+      --gk-violet:    #6B5FD8;
+      --gk-text:      #1A2F4B;
+      --gk-text-2:    #4B6280;
+      --gk-muted:     #8098B5;
+      --gk-border:    rgba(26,47,75,0.10);
+      --gk-border-2:  rgba(26,47,75,0.17);
+    }
+    .gk-nav { background: rgba(247,245,240,0.97) !important; border-bottom-color: rgba(26,47,75,0.10) !important; }
+    .gk-nav-cta { color: #fff !important; }
+    .gk-nav-links.gk-open { background: #fff !important; border-bottom-color: rgba(26,47,75,0.10) !important; }
+    .gk-nav-link.active { color: var(--gk-primary) !important; background: rgba(37,88,217,0.08) !important; }
+
+    *, *::before, *::after { margin:0; padding:0; box-sizing:border-box; }
+    html { scroll-behavior:smooth; }
+    body { font-family:var(--gk-font); background:var(--gk-bg); color:var(--gk-text); overflow-x:hidden; }
+
+    .rp-hero { padding: calc(var(--gk-nav-h) + 4rem) 0 3rem; }
+    .rp-eyebrow { font-size:0.68rem; font-weight:700; letter-spacing:0.2em; text-transform:uppercase; color:var(--gk-teal); margin-bottom:1rem; display:block; }
+    .rp-title { font-size:clamp(2rem,4.5vw,3.2rem); font-weight:900; letter-spacing:-0.03em; line-height:1.12; color:var(--gk-text); margin-bottom:1.25rem; max-width:820px; }
+    .rp-intro { font-size:1.05rem; color:var(--gk-text-2); line-height:1.85; max-width:740px; margin-bottom:1.25rem; }
+    .rp-intro strong { color: var(--gk-text); }
+
+    .rp-toc { background:#fff; border:1px solid var(--gk-border); border-radius:16px; padding:1.75rem 2rem; margin-top:2.5rem; max-width:740px; }
+    .rp-toc-label { font-size:0.68rem; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; color:var(--gk-muted); margin-bottom:1rem; display:block; }
+    .rp-toc ol { list-style:none; counter-reset:rp; display:flex; flex-direction:column; gap:0.65rem; }
+    .rp-toc li { counter-increment:rp; }
+    .rp-toc a { display:flex; align-items:baseline; gap:0.75rem; text-decoration:none; color:var(--gk-text); font-size:0.93rem; font-weight:600; transition:color 0.15s; }
+    .rp-toc a:hover { color:var(--gk-primary); }
+    .rp-toc a::before { content: counter(rp); font-family:var(--gk-mono); font-size:0.78rem; font-weight:700; color:var(--gk-primary); flex-shrink:0; width:1.4rem; }
+
+    .rp-section { padding:4.5rem 0; border-top:1px solid var(--gk-border); }
+    .rp-section:nth-child(odd) { background:#fff; }
+    .rp-tag { display:inline-block; font-size:0.66rem; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; padding:0.3rem 0.8rem; border-radius:999px; margin-bottom:1.25rem; }
+    .rp-tag.blue   { color:var(--gk-primary); background:rgba(37,88,217,0.08); }
+    .rp-tag.teal   { color:var(--gk-teal); background:rgba(42,140,122,0.08); }
+    .rp-tag.amber  { color:var(--gk-amber); background:rgba(201,124,26,0.1); }
+    .rp-tag.violet { color:var(--gk-violet); background:rgba(107,95,216,0.08); }
+    .rp-h2 { font-size:clamp(1.5rem,3vw,2.1rem); font-weight:800; letter-spacing:-0.02em; color:var(--gk-text); margin-bottom:0.5rem; max-width:760px; }
+    .rp-h2-sub { font-size:1rem; color:var(--gk-text-2); margin-bottom:2rem; max-width:700px; }
+    .rp-body { max-width:760px; }
+    .rp-body p { font-size:0.98rem; color:var(--gk-text-2); line-height:1.9; margin-bottom:1.3rem; }
+    .rp-body p:last-child { margin-bottom:0; }
+    .rp-body strong { color: var(--gk-text); }
+    .rp-goeckoh { background:var(--gk-bg-raised); border-radius:14px; padding:1.5rem 1.75rem; margin:1.75rem 0; font-size:0.93rem; color:var(--gk-text-2); line-height:1.85; max-width:760px; }
+    .rp-goeckoh strong { color:var(--gk-primary); }
+
+    /* Price card */
+    .pp-price-card {
+      max-width:520px; background:var(--gk-bg-card); border:2px solid rgba(37,88,217,0.25);
+      border-radius:24px; padding:2.75rem 2.5rem; text-align:center;
+      box-shadow:0 16px 50px rgba(37,88,217,0.10); margin-top:0.5rem;
+    }
+    .pp-price-badge {
+      display:inline-block; background:rgba(37,88,217,0.1); color:var(--gk-primary);
+      font-size:0.7rem; font-weight:700; letter-spacing:0.12em; text-transform:uppercase;
+      padding:0.3rem 0.9rem; border-radius:999px; margin-bottom:1.5rem;
+    }
+    .pp-price-amount { font-size:4rem; font-weight:900; letter-spacing:-0.04em; line-height:1; color:var(--gk-text); }
+    .pp-price-amount span { font-size:1.4rem; font-weight:500; color:var(--gk-text-2); vertical-align:super; margin-right:0.1rem; }
+    .pp-price-per { font-size:0.87rem; color:var(--gk-text-2); margin-top:0.35rem; margin-bottom:2rem; }
+    .pp-price-features { list-style:none; text-align:left; display:flex; flex-direction:column; gap:0.7rem; margin-bottom:2rem; }
+    .pp-price-features li { display:flex; align-items:flex-start; gap:0.75rem; font-size:0.86rem; color:var(--gk-text-2); line-height:1.5; }
+    .pp-price-features li::before { content:'✓'; color:var(--gk-teal); font-weight:800; flex-shrink:0; }
+
+    /* Compare table */
+    .compare-table { width:100%; max-width:760px; border-collapse:collapse; margin:1.75rem 0; font-size:0.86rem; }
+    .compare-table th, .compare-table td { padding:1rem 1.1rem; text-align:left; border-bottom:1px solid var(--gk-border); vertical-align:top; }
+    .compare-table th { font-size:0.64rem; font-weight:700; text-transform:uppercase; letter-spacing:0.08em; color:var(--gk-muted); background:var(--gk-bg-raised); }
+    .compare-table td:first-child { font-weight:700; color:var(--gk-text); white-space:nowrap; }
+    .compare-table .gk-row { background:rgba(37,88,217,0.04); }
+    .compare-table .gk-row td:first-child { color:var(--gk-teal); font-weight:800; }
+    .tag-yes { color:var(--gk-teal); font-weight:700; font-size:0.8rem; }
+    .tag-no  { color:var(--gk-muted); font-size:0.8rem; }
+    @media(max-width:640px){ .compare-table td:first-child { white-space:normal; } }
+
+    /* Billing FAQ */
+    .pp-faq-list { max-width:760px; margin-top:0.5rem; display:flex; flex-direction:column; gap:0; }
+    .pp-faq-item { border-bottom:1px solid var(--gk-border); }
+    .pp-faq-item:first-child { border-top:1px solid var(--gk-border); }
+    .pp-faq-q {
+      width:100%; background:none; border:none; text-align:left; cursor:pointer;
+      padding:1.4rem 0; display:flex; justify-content:space-between; align-items:center; gap:1rem;
+      font-family:var(--gk-font); font-size:0.95rem; font-weight:700; color:var(--gk-text);
+    }
+    .pp-faq-q:hover { color:var(--gk-primary); }
+    .pp-faq-q .pp-faq-arrow { color:var(--gk-muted); font-size:1.2rem; transition:transform 0.2s; flex-shrink:0; }
+    .pp-faq-item.open .pp-faq-arrow { transform:rotate(45deg); }
+    .pp-faq-a { display:none; font-size:0.87rem; color:var(--gk-text-2); line-height:1.85; padding-bottom:1.4rem; max-width:700px; }
+    .pp-faq-item.open .pp-faq-a { display:block; }
+
+    .rp-cta { background:linear-gradient(135deg, #1A2F4B 0%, #1E3D5A 50%, #163547 100%); color:#fff; text-align:center; }
+    .rp-cta h2 { font-size:clamp(1.6rem,3vw,2.2rem); font-weight:800; margin-bottom:1rem; color:#fff; }
+    .rp-cta p { font-size:1rem; color:rgba(255,255,255,0.75); line-height:1.8; max-width:560px; margin:0 auto 1.75rem; }
+  </style>
+</head>
+<body>
+
+<nav class="gk-nav">
+  <a href="index.html" class="gk-nav-brand">
+    <img src="images/logo-light.png" alt="Goeckoh" class="gk-nav-logo">
+    <div>
+      <div class="gk-nav-brand-name">GOECK<span>OH</span></div>
+      <div class="gk-nav-brand-sub">Go Echo</div>
+    </div>
+  </a>
+  <div class="gk-nav-links" id="gkNav">
+    <a href="science.html" class="gk-nav-link">The Science</a>
+    <a href="research.html" class="gk-nav-link">Research</a>
+    <a href="families.html" class="gk-nav-link">For Families</a>
+    <a href="clinicians.html" class="gk-nav-link">For Clinicians</a>
+    <a href="pricing.html" class="gk-nav-link active">Pricing</a>
+    <a href="demo.html" class="gk-nav-link">Try the Demo</a>
+  </div>
+  <a href="download.html" class="gk-nav-cta">Get Early Access</a>
+  <button class="gk-nav-toggle" aria-label="Menu" aria-controls="gkNav" aria-expanded="false"
+    onclick="const nav=document.getElementById('gkNav'); this.setAttribute('aria-expanded', nav.classList.toggle('gk-open'))">☰</button>
+</nav>
+
+<!-- HERO -->
+<section class="rp-hero">
+  <div class="gk-container">
+    <span class="rp-eyebrow">Pricing</span>
+    <h1 class="rp-title">One price. No surprises. No fine print to decode.</h1>
+    <p class="rp-intro">
+      $20 per person, per month, cancel any time. That's the entire pricing model — no
+      tiered feature-gating, no "contact sales" for the basics. This page has the full plan
+      detail, an honest comparison against the alternatives, clinical/district pricing, and
+      the specific billing questions people ask before they commit.
+    </p>
+  </div>
+</section>
+
+<section style="padding-bottom:2rem">
+  <div class="gk-container">
+    <div class="rp-toc">
+      <span class="rp-toc-label">On this page</span>
+      <ol>
+        <li><a href="#the-plan">What's actually included</a></li>
+        <li><a href="#comparison">How it compares to the alternatives</a></li>
+        <li><a href="#clinical-district">Clinical &amp; district pricing</a></li>
+        <li><a href="#billing-faq">Billing questions, answered directly</a></li>
+      </ol>
+    </div>
+  </div>
+</section>
+
+<!-- 1. THE PLAN -->
+<section class="rp-section" id="the-plan">
+  <div class="gk-container">
+    <span class="rp-tag blue">01 · The Plan</span>
+    <h2 class="rp-h2">What's actually included</h2>
+    <p class="rp-h2-sub">Every feature, on the one plan — nothing held back for a higher tier.</p>
+    <div class="pp-price-card">
+      <div class="pp-price-badge">Early Access</div>
+      <div class="pp-price-amount"><span>$</span>20</div>
+      <div class="pp-price-per">per person · per month · cancel any time</div>
+      <ul class="pp-price-features">
+        <li>Unlimited use — no session caps, no daily limits</li>
+        <li>Guardian / caregiver real-time monitoring</li>
+        <li>Correction profiles for ASD, dysarthria, apraxia, and post-stroke/TBI speech changes</li>
+        <li>Real-time voice science dashboard</li>
+        <li>Voice games designed for children with ASD</li>
+        <li>ABA-aligned session progress tracking</li>
+        <li>Works on any phone, tablet, or browser — plus native apps for desktop, Windows, Linux, and Android</li>
+        <li>Your voice data never leaves your device</li>
+        <li>Email support</li>
+      </ul>
+      <a href="download.html" class="gk-btn gk-btn-primary" style="width:100%;justify-content:center;font-size:1rem;padding:0.9rem 1.5rem">
+        Start Early Access →
+      </a>
+    </div>
+    <div class="rp-goeckoh">
+      <strong>Why $20:</strong> we picked a number a family could actually sustain monthly,
+      not one calibrated to what the market would bear. One subscription covers one
+      person — the patient, a family member, or a clinician's own account — and includes
+      everything on this page, not a stripped-down entry tier.
+    </div>
+  </div>
+</section>
+
+<!-- 2. COMPARISON -->
+<section class="rp-section" id="comparison">
+  <div class="gk-container">
+    <span class="rp-tag teal">02 · The Alternatives</span>
+    <h2 class="rp-h2">How it compares to the alternatives</h2>
+    <p class="rp-h2-sub">Current options either cost a fortune, delay your voice, replace it entirely, or only work in a clinic.</p>
+    <div style="overflow-x:auto">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th>Solution</th>
+            <th>Cost</th>
+            <th>Real-time</th>
+            <th>Your voice</th>
+            <th>Works anywhere</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="gk-row">
+            <td>Goeckoh</td>
+            <td><span class="tag-yes">$20/mo</span></td>
+            <td><span class="tag-yes">Yes (&lt;50ms)</span></td>
+            <td><span class="tag-yes">Always</span></td>
+            <td><span class="tag-yes">Any phone</span></td>
+          </tr>
+          <tr>
+            <td>SpeechEasy</td>
+            <td><span class="tag-no">$4,500+</span></td>
+            <td><span class="tag-no">Delayed only</span></td>
+            <td><span class="tag-yes">Yes</span></td>
+            <td><span class="tag-yes">Yes</span></td>
+          </tr>
+          <tr>
+            <td>AAC Devices</td>
+            <td><span class="tag-no">$5K–$15K</span></td>
+            <td><span class="tag-no">No</span></td>
+            <td><span class="tag-no">Synthetic voice</span></td>
+            <td><span class="tag-yes">Yes</span></td>
+          </tr>
+          <tr>
+            <td>Speech Therapy Apps</td>
+            <td><span class="tag-no">$50–200/mo</span></td>
+            <td><span class="tag-no">No</span></td>
+            <td><span class="tag-yes">Yes</span></td>
+            <td><span class="tag-yes">Yes</span></td>
+          </tr>
+          <tr>
+            <td>In-clinic Therapy</td>
+            <td><span class="tag-no">$100–250/session</span></td>
+            <td><span class="tag-yes">Yes</span></td>
+            <td><span class="tag-yes">Yes</span></td>
+            <td><span class="tag-no">Clinic only</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="rp-body" style="margin-top:1.75rem">
+      <p>
+        None of these are exact substitutes for each other, and Goeckoh isn't positioned to
+        replace in-clinic therapy — see the honest framing on that in
+        <a href="families.html#realistic-expectations" style="color:var(--gk-primary)">What's Realistic to Expect</a>.
+        The comparison is about which tools actually close the real-time feedback loop
+        described on the <a href="science.html" style="color:var(--gk-primary)">Science
+        page</a>, and at what cost.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- 3. CLINICAL & DISTRICT -->
+<section class="rp-section" id="clinical-district">
+  <div class="gk-container">
+    <span class="rp-tag violet">03 · Clinical &amp; District</span>
+    <h2 class="rp-h2">Clinical &amp; district pricing</h2>
+    <p class="rp-h2-sub">For clinics and schools managing more than a handful of patients.</p>
+    <div class="rp-body">
+      <p>
+        The standard $20/month plan works fine for an individual clinician monitoring a small
+        caseload. For clinics or school districts managing a larger number of patients, we
+        offer volume pricing rather than asking you to purchase individual subscriptions one
+        at a time. Reach out directly and we'll work out pricing based on your caseload size —
+        <a href="mailto:care@goeckoh.com" style="color:var(--gk-primary)">care@goeckoh.com</a>.
+        For what a clinician actually gets — remote monitoring, session data fields, and
+        correction profiles — see the
+        <a href="clinicians.html" style="color:var(--gk-primary)">For Clinicians</a> page.
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- 4. BILLING FAQ -->
+<section class="rp-section" id="billing-faq">
+  <div class="gk-container">
+    <span class="rp-tag amber">04 · Billing FAQ</span>
+    <h2 class="rp-h2">Billing questions, answered directly</h2>
+    <p class="rp-h2-sub">The things people actually ask before they enter a card number.</p>
+    <div class="pp-faq-list">
+      <div class="pp-faq-item">
+        <button class="pp-faq-q" onclick="toggleFaq(this)">
+          Can I cancel any time?
+          <span class="pp-faq-arrow">+</span>
+        </button>
+        <div class="pp-faq-a">
+          Yes. There's no minimum commitment or contract term. Cancel whenever you like from
+          your account page, and you won't be billed again after the current period ends.
+        </div>
+      </div>
+      <div class="pp-faq-item">
+        <button class="pp-faq-q" onclick="toggleFaq(this)">
+          What happens to our session data if we cancel?
+          <span class="pp-faq-arrow">+</span>
+        </button>
+        <div class="pp-faq-a">
+          Nothing changes on the data side — session history lives in your own browser's
+          local storage on the device it was created on, regardless of subscription status.
+          Cancelling stops the correction engine from running and stops billing; it doesn't
+          delete anything already stored on your device, and there's nothing stored on our
+          servers to delete in the first place beyond your account email and subscription
+          status.
+        </div>
+      </div>
+      <div class="pp-faq-item">
+        <button class="pp-faq-q" onclick="toggleFaq(this)">
+          Do I need a separate subscription per device?
+          <span class="pp-faq-arrow">+</span>
+        </button>
+        <div class="pp-faq-a">
+          No — one subscription covers one person, and that person's license key activates
+          across a small number of their own devices (for example, a phone and a tablet), not
+          just one. It's priced per person, not per device.
+        </div>
+      </div>
+      <div class="pp-faq-item">
+        <button class="pp-faq-q" onclick="toggleFaq(this)">
+          Is there a free trial?
+          <span class="pp-faq-arrow">+</span>
+        </button>
+        <div class="pp-faq-a">
+          The <a href="demo.html" style="color:var(--gk-primary)">live demo</a> is free with no
+          signup and no time limit on the silent analysis mode — you can hear the actual
+          correction technology working on your own voice before paying anything. Press,
+          conferences, and partner clinics occasionally receive comp access codes directly;
+          if you were given one, redeem it from the
+          <a href="download.html" style="color:var(--gk-primary)">early access page</a>.
+        </div>
+      </div>
+      <div class="pp-faq-item">
+        <button class="pp-faq-q" onclick="toggleFaq(this)">
+          What payment methods are accepted?
+          <span class="pp-faq-arrow">+</span>
+        </button>
+        <div class="pp-faq-a">
+          Checkout is handled by Stripe, which supports major credit and debit cards. We never
+          see or store your card details directly.
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CLOSING CTA -->
+<section class="rp-cta">
+  <div class="gk-container">
+    <h2>Try it before you pay for it.</h2>
+    <p>
+      The free demo runs the real correction engine on your own voice — no signup required.
+    </p>
+    <div style="display:flex; gap:0.85rem; justify-content:center; flex-wrap:wrap">
+      <a href="demo.html" class="gk-btn gk-btn-teal">Try the Demo →</a>
+      <a href="download.html" class="gk-btn gk-btn-secondary" style="color:#fff;border-color:rgba(255,255,255,0.3)">Start Early Access →</a>
+    </div>
+  </div>
+</section>
+
+<footer class="gk-footer gk-container">
+  <div class="gk-footer-brand">GOECK<span>OH</span> — Go Echo</div>
+  <div class="gk-footer-links">
+    <a href="index.html">Home</a>
+    <a href="science.html">Science</a>
+    <a href="research.html">Research</a>
+    <a href="families.html">For Families</a>
+    <a href="clinicians.html">For Clinicians</a>
+    <a href="pricing.html">Pricing</a>
+    <a href="demo.html">Demo</a>
+    <a href="mailto:care@goeckoh.com">Contact</a>
+  </div>
+  <div class="gk-footer-copy">© <span id="yr"></span> Goeckoh. All rights reserved.</div>
+</footer>
+
+<script>
+  document.getElementById('yr').textContent = new Date().getFullYear();
+  function toggleFaq(btn) {
+    const item = btn.closest('.pp-faq-item');
+    const wasOpen = item.classList.contains('open');
+    document.querySelectorAll('.pp-faq-item.open').forEach(i => i.classList.remove('open'));
+    if (!wasOpen) item.classList.add('open');
+  }
+</script>
+</body>
+</html>

--- a/goeckoh-site/research.html
+++ b/goeckoh-site/research.html
@@ -127,7 +127,7 @@
     <a href="research.html" class="gk-nav-link active">Research</a>
     <a href="families.html" class="gk-nav-link">For Families</a>
     <a href="clinicians.html" class="gk-nav-link">For Clinicians</a>
-    <a href="index.html#pricing" class="gk-nav-link">Pricing</a>
+    <a href="pricing.html" class="gk-nav-link">Pricing</a>
     <a href="demo.html" class="gk-nav-link">Try the Demo</a>
   </div>
   <a href="download.html" class="gk-nav-cta">Get Early Access</a>
@@ -597,7 +597,7 @@
     </p>
     <div style="display:flex; gap:0.85rem; justify-content:center; flex-wrap:wrap">
       <a href="demo.html" class="gk-btn gk-btn-teal">Try the Demo →</a>
-      <a href="index.html#pricing" class="gk-btn gk-btn-secondary" style="color:#fff;border-color:rgba(255,255,255,0.3)">See Pricing</a>
+      <a href="pricing.html" class="gk-btn gk-btn-secondary" style="color:#fff;border-color:rgba(255,255,255,0.3)">See Pricing</a>
     </div>
   </div>
 </section>
@@ -608,7 +608,7 @@
     <a href="index.html">Home</a>
     <a href="index.html#science">Science</a>
     <a href="research.html">Research</a>
-    <a href="index.html#pricing">Pricing</a>
+    <a href="pricing.html">Pricing</a>
     <a href="demo.html">Demo</a>
     <a href="mailto:care@goeckoh.com">Contact</a>
   </div>

--- a/goeckoh-site/science.html
+++ b/goeckoh-site/science.html
@@ -127,7 +127,7 @@
     <a href="research.html" class="gk-nav-link">Research</a>
     <a href="families.html" class="gk-nav-link">For Families</a>
     <a href="clinicians.html" class="gk-nav-link">For Clinicians</a>
-    <a href="index.html#pricing" class="gk-nav-link">Pricing</a>
+    <a href="pricing.html" class="gk-nav-link">Pricing</a>
     <a href="demo.html" class="gk-nav-link">Try the Demo</a>
   </div>
   <a href="download.html" class="gk-nav-cta">Get Early Access</a>
@@ -430,7 +430,7 @@
     <a href="index.html">Home</a>
     <a href="science.html">Science</a>
     <a href="research.html">Research</a>
-    <a href="index.html#pricing">Pricing</a>
+    <a href="pricing.html">Pricing</a>
     <a href="demo.html">Demo</a>
     <a href="mailto:care@goeckoh.com">Contact</a>
   </div>


### PR DESCRIPTION
## Summary
Fifth and final page converted from a homepage anchor into a real page (Research, Science, For Families, and For Clinicians already merged). This completes the change requested after feedback that the nav tabs just scrolling down one page read as thin and thrown-together.

`pricing.html` covers:
- The single $20/mo plan in full, with the same feature list as the homepage card
- An honest comparison against SpeechEasy, AAC devices, speech therapy apps, and in-clinic therapy, without positioning Goeckoh as a replacement for clinical care
- Clinical/district volume pricing
- A billing FAQ answering the specific questions people ask before entering a card number (cancellation, what happens to data on cancel, per-device vs. per-person licensing, free trial, payment methods)

Nav/footer updated across `index.html`, `science.html`, `research.html`, `families.html`, and `clinicians.html` from the `#pricing` anchor to `pricing.html`. Homepage pricing card links through to the full page.

With this merged, all five nav sections (The Science, Research, For Families, For Clinicians, Pricing) are real standalone pages instead of homepage scroll anchors.

## Test plan
- [x] Verified in a headless browser: no console errors, FAQ accordion toggle works, homepage → pricing.html CTA link works
- [x] Confirmed nav/footer updated from `#pricing` anchor to `pricing.html` across all pages


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Add a dedicated pricing page and update navigation links to point to it instead of the homepage pricing anchor.

New Features:
- Introduce a standalone pricing.html page describing the $20/month plan, comparisons to alternatives, clinical/district pricing, and a billing FAQ.

Enhancements:
- Update navigation and footer links across all site pages to route to the new pricing.html page, and add a CTA from the homepage pricing card to the full pricing page.