### PR TITLE
Bring the demo's nav in line with the site, fix a false technical claim

### DIFF
--- a/goeckoh-site/demo.html
+++ b/goeckoh-site/demo.html
@@ -801,15 +801,16 @@
     </div>
   </a>
   <div class="gk-nav-links" id="gkNav">
-    <a href="demo.html"                                       class="gk-nav-link active">Live Demo</a>
-    <a href="real_time_therapeutic_voice_cloning_system.html" class="gk-nav-link">Echo Therapy</a>
-    <a href="advanced_voice_visualizer_pro.html"              class="gk-nav-link">Visualizer</a>
-    <a href="voice_therapy_profile_transform.html"            class="gk-nav-link">Profile Lab</a>
-    <a href="goeckoh_dashboard.html"                          class="gk-nav-link">Dashboard</a>
-    <a href="index.html"                                      class="gk-nav-link">Science</a>
+    <a href="demo.html"       class="gk-nav-link active">Live Demo</a>
+    <a href="science.html"    class="gk-nav-link">The Science</a>
+    <a href="research.html"   class="gk-nav-link">Research</a>
+    <a href="families.html"   class="gk-nav-link">For Families</a>
+    <a href="clinicians.html" class="gk-nav-link">For Clinicians</a>
+    <a href="pricing.html"    class="gk-nav-link">Pricing</a>
   </div>
-  <a href="download.html" class="gk-nav-cta">Download</a>
-  <button class="gk-nav-toggle" onclick="document.getElementById('gkNav').classList.toggle('gk-open')" aria-label="Menu">☰</button>
+  <a href="download.html" class="gk-nav-cta">Get Early Access</a>
+  <button class="gk-nav-toggle" aria-label="Menu" aria-controls="gkNav" aria-expanded="false"
+    onclick="const nav=document.getElementById('gkNav'); this.setAttribute('aria-expanded', nav.classList.toggle('gk-open'))">☰</button>
 </nav>
 
 <!-- ══════════════════════ HERO ══════════════════════ -->
@@ -1077,12 +1078,14 @@
     </div>
 
     <div class="timeline-note">
-      * &lt;50 ms refers to the <strong>native on-device processing latency</strong> of Goeckoh's
-      DSP engine (Rust-compiled, running directly on the device's audio hardware). This demo shows
-      analysis only; the correction is delivered through the full application running natively.
-      Total perceived latency also includes Bluetooth earbud round-trip, which varies by hardware
-      (typically 40–150 ms). Even at the upper range, correction arrives inside the 200 ms
-      prediction window, with margin remaining before the 250 ms hard cutoff below.
+      * &lt;50 ms refers to the processing latency of Goeckoh's correction pipeline itself —
+      the same LPC-12 formant analysis and biquad correction engine described in full on the
+      <a href="science.html" style="color:inherit;text-decoration:underline">Science page</a>,
+      running in "Hear The Correction" above exactly as it runs in the full application; this
+      demo is not a simulation of it. Total perceived latency also includes Bluetooth earbud
+      round-trip, which varies by hardware (typically 40–150 ms). Even at the upper range,
+      correction arrives inside the 200 ms prediction window, with margin remaining before the
+      250 ms hard cutoff below.
       <br><br>
       <strong>N1 Suppression:</strong> When the correction arrives on time, the auditory cortex
       suppresses the N1 evoked potential — an EEG marker indicating the brain accepted the corrected


### PR DESCRIPTION
## Summary
Asked to improve the demo. Audited the page (code + live render) and found two real problems, distinct from the sample-rate bugs already fixed in #43/#44:

1. **The nav was a completely separate system from the rest of the site** — pointing at internal app tool pages ("Echo Therapy", "Visualizer", "Profile Lab", "Dashboard") instead of the marketing pages built this session (Science, Research, For Families, For Clinicians, Pricing). A visitor arriving at the demo from any of those pages got dropped into disconnected navigation with no way back except the browser's back button. Replaced with the same nav used everywhere else, plus the same accessible nav-toggle pattern (`aria-expanded`/`aria-controls`) already applied to the other pages.

2. **A footnote made a false technical claim.** It said the demo's <50ms latency figure was for a separate "native on-device processing... Rust-compiled" engine, and that "this demo shows analysis only; the correction is delivered through the full application running natively." Neither is true — there's no Rust engine anywhere in this codebase, and the page's own "Hear The Correction" button demonstrably delivers real audio correction via the same JS/AudioWorklet pipeline documented on `science.html`. Rewrote the footnote to accurately describe what's actually running, with a link to the Science page's full pipeline writeup.

## Test plan
- [x] Verified in a headless browser: no console/page errors, all 5 new nav links resolve to the correct pages
- [x] Confirmed mobile nav toggle opens/closes correctly with proper `aria-expanded` state
- [x] Visually confirmed the corrected footnote renders correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Align the demo page navigation and latency documentation with the rest of the site and the actual behavior of the correction pipeline.

New Features:
- Expose links from the demo page to the main marketing sections: Science, Research, For Families, For Clinicians, and Pricing.

Enhancements:
- Bring the demo nav and mobile menu toggle behavior in line with the site's global navigation pattern, including accessible toggle semantics.
- Update the demo page CTA text to match the site's early-access messaging.
- Revise the latency footnote to accurately describe the correction pipeline used by the demo and link to the detailed Science documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated demo navigation to reflect current site sections.
  * Renamed the call-to-action to “Get Early Access.”

* **Documentation**
  * Clarified latency information, distinguishing processing latency from Bluetooth round-trip latency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->