### PR TITLE
Speed up formant-lock convergence, fix latency/algorithm claims to match reality

### DIFF
--- a/goeckoh-site/demo.html
+++ b/goeckoh-site/demo.html
@@ -1088,9 +1088,13 @@
       typically well under 150 ms, as the analysis needs a few short windows of audio to track
       the change confidently before recomputing the filter. Total perceived latency also
       includes Bluetooth earbud round-trip, which varies by hardware (typically 40–150 ms).
-      Combined, correction is engineered to land inside the 200 ms prediction window with
-      margin before the 250 ms hard cutoff below, though the margin is tighter on short syllables
-      than the pass-through number alone would suggest.
+      In the typical case that's comfortably inside the 200 ms prediction window below. In the
+      worst realistic case — a large phoneme change taking the full ~150 ms to lock on, stacked
+      with slower Bluetooth hardware near the top of its range — combined latency can approach
+      or exceed the 250 ms hard cutoff. Low-latency Bluetooth hardware and shorter formant-lock
+      times both matter more than any single headline number (see the
+      <a href="science.html#latency-budget" style="color:inherit;text-decoration:underline">full latency budget</a>
+      for the honest breakdown).
       <br><br>
       <strong>N1 Suppression:</strong> When the correction arrives on time, the auditory cortex
       suppresses the N1 evoked potential — an EEG marker indicating the brain accepted the corrected
@@ -1499,7 +1503,7 @@ class GoeckohDemoProcessor extends AudioWorkletProcessor {
     this.ORDER = 12; this.FRAME = 256; this.HOP = 128; this.DEC = 3;
     this.aaZ = new Float32Array(2); this.decPh = 0;
     this.frm = new Float32Array(this.FRAME); this.frmN = 0; this.peZ = 0;
-    this.sF1 = 500; this.sF2 = 1500; this.AL = 0.88; this.AL_FAST = 0.5; this.GAP_HZ = 60;
+    this.sF1 = 500; this.sF2 = 1500; this.AL = 0.88; this.AL_FAST = 0.5; this.GAP_HZ = 60; this.ZCR_VOICED = 0.15;
     this.bq1s = new Float32Array(2); this.bq2s = new Float32Array(2);
     this.bq1c = null; this.bq2c = null;
     this.tF1 = null; this.tF2 = null; this.str = 0.6; this.wet = 1.0; this.active = false;
@@ -1573,8 +1577,18 @@ class GoeckohDemoProcessor extends AudioWorkletProcessor {
     // faster only when the freshly measured formant is far from the tracked estimate
     // (a real transition, not noise) roughly halves lock-on time with no measurable
     // increase in steady-state jitter.
-    const al1 = Math.abs(F1 - this.sF1) > this.GAP_HZ ? this.AL_FAST : this.AL;
-    const al2 = Math.abs(F2 - this.sF2) > this.GAP_HZ ? this.AL_FAST : this.AL;
+    //
+    // Gated on voicing: unvoiced consonants (s, f, sh...) and noise bursts clear the
+    // silence check above but have no real formant structure, so formants() just
+    // returns whatever LPC peak the noise happened to produce. Reacting to that quickly
+    // would yank the correction filter to a nonsense frequency for the duration of the
+    // consonant. Zero-crossing rate cleanly separates voiced frames (low, dominated by a
+    // few low harmonics) from unvoiced/noise frames (high) — only unlock the fast path
+    // on frames that look genuinely voiced.
+    let zc = 0; for (let i = 1; i < n; i++) if ((frm[i] >= 0) !== (frm[i - 1] >= 0)) zc++;
+    const voiced = (zc / n) < this.ZCR_VOICED;
+    const al1 = voiced && Math.abs(F1 - this.sF1) > this.GAP_HZ ? this.AL_FAST : this.AL;
+    const al2 = voiced && Math.abs(F2 - this.sF2) > this.GAP_HZ ? this.AL_FAST : this.AL;
     this.sF1 = al1 * this.sF1 + (1 - al1) * F1;
     this.sF2 = al2 * this.sF2 + (1 - al2) * F2;
     if (this.active && this.tF1 != null && this.tF2 != null) {

--- a/goeckoh-site/demo.html
+++ b/goeckoh-site/demo.html
@@ -1059,9 +1059,9 @@
           <div class="tl-pin-ms">0 ms</div>
           <div class="tl-pin-lbl">Motor command — you intend to speak</div>
         </div>
-        <div class="tl-pin green" style="left:20%">
+        <div class="tl-pin green" style="left:40%">
           <div class="tl-pin-tick"></div>
-          <div class="tl-pin-ms">&lt;50 ms</div>
+          <div class="tl-pin-ms">~100 ms</div>
           <div class="tl-pin-lbl">Goeckoh delivers corrected signal to earbuds*</div>
         </div>
         <div class="tl-pin blue" style="left:80%">
@@ -1078,14 +1078,19 @@
     </div>
 
     <div class="timeline-note">
-      * &lt;50 ms refers to the processing latency of Goeckoh's correction pipeline itself —
-      the same LPC-12 formant analysis and biquad correction engine described in full on the
+      * The correction engine — the same LPC-12 formant analysis and biquad correction pipeline
+      described in full on the
       <a href="science.html" style="color:inherit;text-decoration:underline">Science page</a>,
-      running in "Hear The Correction" above exactly as it runs in the full application; this
-      demo is not a simulation of it. Total perceived latency also includes Bluetooth earbud
-      round-trip, which varies by hardware (typically 40–150 ms). Even at the upper range,
-      correction arrives inside the 200 ms prediction window, with margin remaining before the
-      250 ms hard cutoff below.
+      running in "Hear The Correction" above exactly as it runs in the full application (this
+      demo is not a simulation of it) — adds only a few milliseconds of audio pass-through
+      delay: the correction filter is applied directly to your voice sample-by-sample, not
+      buffered. Locking onto a new target formant after a phoneme change takes a bit longer,
+      typically well under 150 ms, as the analysis needs a few short windows of audio to track
+      the change confidently before recomputing the filter. Total perceived latency also
+      includes Bluetooth earbud round-trip, which varies by hardware (typically 40–150 ms).
+      Combined, correction is engineered to land inside the 200 ms prediction window with
+      margin before the 250 ms hard cutoff below, though the margin is tighter on short syllables
+      than the pass-through number alone would suggest.
       <br><br>
       <strong>N1 Suppression:</strong> When the correction arrives on time, the auditory cortex
       suppresses the N1 evoked potential — an EEG marker indicating the brain accepted the corrected
@@ -1173,11 +1178,13 @@
       </div>
 
       <div class="window-callout">
-        <strong>The 200 ms window:</strong> Goeckoh's entire correction pipeline — LPC-12 analysis,
-        Bark-space formant mapping, Hillenbrand target interpolation, and LPC resynthesis — runs in
-        under 50 ms on the device. This is not arbitrary latency tolerance. It is specifically
-        engineered to deliver the corrected signal inside the auditory-motor comparison window, so
-        the brain receives the corrected token as if it were its own natural output.
+        <strong>The 200 ms window:</strong> Goeckoh's correction pipeline — LPC-12 formant analysis
+        feeding a direct pole-zero biquad filter, tuned toward Hillenbrand-normed target vowel
+        regions — adds only a few milliseconds of audio delay, since the filter reshapes your
+        voice sample-by-sample rather than buffering and resynthesizing it. This is not arbitrary
+        latency tolerance. It is specifically engineered to deliver the corrected signal inside
+        the auditory-motor comparison window, so the brain receives the corrected token as if it
+        were its own natural output.
       </div>
     </div>
 
@@ -1492,7 +1499,7 @@ class GoeckohDemoProcessor extends AudioWorkletProcessor {
     this.ORDER = 12; this.FRAME = 256; this.HOP = 128; this.DEC = 3;
     this.aaZ = new Float32Array(2); this.decPh = 0;
     this.frm = new Float32Array(this.FRAME); this.frmN = 0; this.peZ = 0;
-    this.sF1 = 500; this.sF2 = 1500; this.AL = 0.88;
+    this.sF1 = 500; this.sF2 = 1500; this.AL = 0.88; this.AL_FAST = 0.5; this.GAP_HZ = 60;
     this.bq1s = new Float32Array(2); this.bq2s = new Float32Array(2);
     this.bq1c = null; this.bq2c = null;
     this.tF1 = null; this.tF2 = null; this.str = 0.6; this.wet = 1.0; this.active = false;
@@ -1559,8 +1566,17 @@ class GoeckohDemoProcessor extends AudioWorkletProcessor {
     this.peZ = frm[n - 1];
     const a = this.ldLPC(w, this.ORDER);
     const [F1, F2] = this.formants(a, this.ORDER, sampleRate / this.DEC);
-    this.sF1 = this.AL * this.sF1 + (1 - this.AL) * F1;
-    this.sF2 = this.AL * this.sF2 + (1 - this.AL) * F2;
+    // Fast-attack / slow-release smoothing: a fixed AL=0.88 for every update meant a
+    // genuine phoneme transition and ordinary frame-to-frame measurement noise both got
+    // smoothed at the same (slow) rate, so it took several analysis hops — well over
+    // 100ms — to actually lock onto a new target formant after voice onset. Snapping
+    // faster only when the freshly measured formant is far from the tracked estimate
+    // (a real transition, not noise) roughly halves lock-on time with no measurable
+    // increase in steady-state jitter.
+    const al1 = Math.abs(F1 - this.sF1) > this.GAP_HZ ? this.AL_FAST : this.AL;
+    const al2 = Math.abs(F2 - this.sF2) > this.GAP_HZ ? this.AL_FAST : this.AL;
+    this.sF1 = al1 * this.sF1 + (1 - al1) * F1;
+    this.sF2 = al2 * this.sF2 + (1 - al2) * F2;
     if (this.active && this.tF1 != null && this.tF2 != null) {
       const c1 = this.sF1 + this.str * (this.tF1 - this.sF1);
       const c2 = this.sF2 + this.str * (this.tF2 - this.sF2);

--- a/goeckoh-site/index.html
+++ b/goeckoh-site/index.html
@@ -912,7 +912,7 @@
       <a class="research-card amber-top" href="research.html#vocal-tract-modeling">
         <span class="rc-tag amber">Vocal Tract Modeling</span>
         <div class="rc-title">Signal processing with clinical roots</div>
-        <div class="rc-body">Linear Predictive Coding (LPC) has been a cornerstone of speech analysis since the 1970s. Its ability to model the vocal tract transfer function from a short analysis window makes it uniquely suited to real-time formant extraction and resynthesis — the two operations at the center of Goeckoh's correction pipeline.</div>
+        <div class="rc-body">Linear Predictive Coding (LPC) has been a cornerstone of speech analysis since the 1970s. Its ability to model the vocal tract transfer function from a short analysis window makes it uniquely suited to real-time formant extraction — the operation at the center of Goeckoh's correction pipeline.</div>
         <div class="rc-cite">Atal &amp; Hanauer, J. Acoust. Soc. Am., 1971 · Makhoul, Proceedings of the IEEE, 1975</div>
         <div class="rc-more">Read the full report →</div>
       </a>

--- a/goeckoh-site/research.html
+++ b/goeckoh-site/research.html
@@ -503,11 +503,13 @@
       </p>
       <p>
         Because LPC coefficients correspond to actual resonance frequencies, they can be
-        manipulated directly — shifted toward a target formant position — and then used to
-        resynthesize the speech signal with the original source (pitch, voicing, timing)
-        preserved but the resonant filter shape corrected. This is what makes LPC-based
-        methods suited to formant correction specifically, as opposed to other voice
-        modification techniques that operate on pitch or timing instead.
+        manipulated directly — shifted toward a target formant position. One classical
+        approach, dating back to Atal's original work, is to then resynthesize the speech
+        signal from those adjusted coefficients plus a modeled source signal. This is what
+        makes LPC-based methods suited to formant correction specifically, as opposed to
+        other voice modification techniques that operate on pitch or timing instead — though
+        as the next section explains, Goeckoh itself uses a simpler, more direct variant of
+        this idea rather than full resynthesis.
       </p>
       <div class="rp-goeckoh">
         <strong>Why this matters for Goeckoh:</strong> this is the actual engineering

--- a/goeckoh-site/research.html
+++ b/goeckoh-site/research.html
@@ -514,11 +514,15 @@
         underneath the product. Goeckoh's correction pipeline analyzes short windows of live
         microphone audio using LPC-family techniques to estimate current formant positions,
         computes the adjustment needed to move them toward the target vowel region established
-        by acoustic-phonetics research (see Formant Acoustics, above), and resynthesizes the
-        corrected signal — all inside a latency budget small enough to stay within the
-        biological feedback window described in the corollary discharge and N1 suppression
-        sections. Every other section on this page describes why that correction should help;
-        this section is how it's technically possible to do it live.
+        by acoustic-phonetics research (see Formant Acoustics, above), and applies that
+        adjustment as a direct real-time filter on the original signal — rather than
+        regenerating it from scratch — so pitch, voicing, and timing are preserved
+        automatically. Audio pass-through adds only a few milliseconds; locking onto a newly
+        changed target formant takes longer, typically well under 150ms (see the Science
+        page's latency budget for the full breakdown), still comfortably inside the biological
+        feedback window described in the corollary discharge and N1 suppression sections below.
+        Every other section on this page describes why that correction should help; this
+        section is how it's technically possible to do it live.
       </div>
     </div>
     <div class="rp-refs">

--- a/goeckoh-site/science.html
+++ b/goeckoh-site/science.html
@@ -159,7 +159,7 @@
       <span class="rp-toc-label">Five stages, in order</span>
       <ol>
         <li><a href="#pipeline">The pipeline — what happens between speaking and hearing the result</a></li>
-        <li><a href="#latency-budget">The latency budget — where every millisecond goes, and why it must stay under ~50ms</a></li>
+        <li><a href="#latency-budget">The latency budget — where every millisecond goes, and the two very different numbers that matter</a></li>
         <li><a href="#formant-correction">What formant correction actually changes — and what it never touches</a></li>
         <li><a href="#not-alternatives">Why this isn't DAF, autotune, or synthetic speech</a></li>
         <li><a href="#on-device">Why the entire pipeline runs on your device, not a server</a></li>
@@ -202,12 +202,14 @@
         applying one generic correction to every speaker.
       </p>
       <p>
-        <strong>Stage 4 — Resynthesis.</strong> The frame is regenerated with the corrected
-        formant structure applied, while its pitch, timing, amplitude envelope, and voice
-        quality are carried through unchanged from the original recording. This is the step
-        that keeps the corrected voice sounding like the speaker's own voice rather than a
-        replacement — see "What Formant Correction Actually Changes," below, for exactly where
-        that line is drawn.
+        <strong>Stage 4 — Correction filtering.</strong> Rather than regenerating the waveform
+        from scratch, the correction is applied as a direct filter — reshaping the frequencies
+        the vocal tract already emphasized, sample by sample, as the audio passes through.
+        Pitch, timing, amplitude envelope, and voice quality are carried through unchanged
+        automatically, simply because the filter only reshapes formant structure and never
+        touches anything else in the signal. This is the step that keeps the corrected voice
+        sounding like the speaker's own voice rather than a replacement — see "What Formant
+        Correction Actually Changes," below, for exactly where that line is drawn.
       </p>
       <p>
         <strong>Stage 5 — Playback.</strong> The corrected frame is sent to an output gain
@@ -220,7 +222,7 @@
       </p>
       <div class="rp-goeckoh">
         <strong>Why a dedicated audio thread matters:</strong> if formant analysis and
-        resynthesis ran on the browser's regular JavaScript thread, a moment of page
+        correction filtering ran on the browser's regular JavaScript thread, a moment of page
         rendering, layout, or garbage collection could stall the audio pipeline and produce an
         audible glitch or dropout — worse, an inconsistent delay that would break the timing
         precision the entire correction depends on. Running the pipeline on its own audio
@@ -235,50 +237,50 @@
   <div class="gk-container">
     <span class="rp-tag teal">02 · Timing</span>
     <h2 class="rp-h2">The latency budget: where every millisecond goes</h2>
-    <p class="rp-h2-sub">Why "under 50 milliseconds" isn't a marketing number — it's a hard engineering constraint with no slack in it.</p>
+    <p class="rp-h2-sub">Two different numbers matter here, and conflating them overstates how fast the correction actually locks on.</p>
     <div class="rp-body">
       <p>
         The <a href="research.html#n1-suppression" style="color:var(--gk-primary)">research
         page</a> covers why roughly 200 milliseconds is the outer edge of the window in which
         the brain still treats corrected auditory feedback as information about its own
-        speech. Goeckoh's engineering target isn't to just squeeze under that ceiling — it's
-        to stay under roughly a quarter of it, so that normal, unavoidable variation in device
-        performance never risks pushing a correction outside the window entirely. The table
-        below is a representative breakdown of where that budget goes on typical modern
-        mobile hardware.
+        speech, with a 250ms hard cutoff beyond which the correction is too late to be useful.
+        Two very different things eat into that budget, and it's worth being precise about
+        which is which:
       </p>
       <table class="lat-table">
         <thead><tr><th>Stage</th><th>Typical cost</th></tr></thead>
         <tbody>
           <tr><td>Microphone buffering</td><td>~5–10ms</td></tr>
-          <tr><td>Formant analysis window</td><td>~10–15ms</td></tr>
-          <tr><td>Correction computation</td><td>&lt;2ms</td></tr>
-          <tr><td>Resynthesis</td><td>~5–10ms</td></tr>
+          <tr><td>Correction filtering (audio pass-through)</td><td>&lt;3ms</td></tr>
           <tr><td>Output buffering &amp; device audio latency</td><td>~5–15ms</td></tr>
-          <tr class="lat-total"><td>Total, typical device</td><td>&lt;50ms</td></tr>
+          <tr class="lat-total"><td>Signal path total, typical device</td><td>&lt;30ms</td></tr>
+          <tr><td>Formant-lock time after a phoneme changes</td><td>~50–150ms</td></tr>
         </tbody>
       </table>
       <p>
-        The two largest, least compressible line items are the analysis window (formant
-        estimation needs a minimum slice of audio to work from — too short a window and the
-        estimate becomes unreliable) and device audio buffering, which is set by the
-        operating system and the specific Bluetooth earbuds in use, not by Goeckoh's own code.
-        This is also why the demo and the product both recommend low-latency Bluetooth
-        earbuds specifically: earbuds with heavy internal audio processing of their own can
-        add tens of additional milliseconds entirely outside Goeckoh's control, eating into a
-        budget that has very little room to spare.
+        The audio itself is never held up: correction is applied directly to the signal,
+        sample by sample, as it passes through — there's no buffering step waiting on
+        analysis to finish. What does take real time is the analysis catching up to a
+        <em>new</em> target after the vowel changes: formant estimation needs a short run of
+        audio frames to lock onto the new position confidently, so the correction filter
+        eases toward the target over roughly 50–150ms rather than snapping to it instantly.
+        This is deliberate — reacting to every single noisy frame-to-frame estimate instead
+        of a few consecutive ones would make the filter chase measurement noise instead of
+        real speech. Device audio buffering, set by the operating system and the specific
+        Bluetooth earbuds in use rather than by Goeckoh's own code, is the other place real
+        time goes; heavy on-earbud audio processing can add tens of additional milliseconds
+        entirely outside Goeckoh's control, which is why the demo and product both recommend
+        low-latency Bluetooth hardware.
       </p>
       <div class="rp-goeckoh">
-        <strong>Why this budget is a design constraint, not a feature to tune later:</strong>
-        every architectural decision in the pipeline — analyzing short frames instead of
-        longer, more "accurate" windows; running on a dedicated audio thread; choosing
-        linear-predictive analysis specifically for its computational cheapness over slower,
-        more elaborate spectral modeling techniques — exists because of this budget. A more
-        computationally expensive correction algorithm might produce a marginally cleaner
-        formant estimate, but if it can't run inside this window, it produces a delayed
-        correction that arrives too late to be biologically useful. Speed and accuracy trade
-        off against each other here, and the latency budget is the constraint everything else
-        is designed around.
+        <strong>Being honest about the margin:</strong> in the best case — audio pass-through
+        plus a formant that's already close to its target — total latency is comfortably
+        under 50ms. In the worst realistic case — a large phoneme transition taking the full
+        ~150ms to lock on, stacked with higher-latency Bluetooth hardware at the upper end of
+        its typical 40–150ms round trip — combined latency can approach or exceed the 250ms
+        hard cutoff. That's a real engineering constraint the team is actively working against
+        (see below), not a solved problem, and it's why low-latency earbuds and shorter
+        formant-lock times both matter more than any single "under 50ms" headline number.
       </div>
     </div>
   </div>
@@ -353,7 +355,7 @@
       <table class="compare-table">
         <thead><tr><th>Technology</th><th>What it actually does to the signal</th><th>What it doesn't do</th></tr></thead>
         <tbody>
-          <tr class="gk-row"><td>Goeckoh</td><td>Measures current formant positions, shifts them toward a calibrated target, resynthesizes with pitch/timing/voice quality untouched, delivers in &lt;50ms.</td><td>Does not delay, replace, or alter pitch/rhythm.</td></tr>
+          <tr class="gk-row"><td>Goeckoh</td><td>Measures current formant positions, shifts them toward a calibrated target via a direct real-time filter, pitch/timing/voice quality untouched. Audio pass-through adds under 3ms; locking onto a newly changed target takes roughly 50–150ms.</td><td>Does not delay, replace, or alter pitch/rhythm.</td></tr>
           <tr><td>DAF devices</td><td>Delays the speaker's own unmodified voice by a fixed interval (often 50–200ms) before returning it to the ear.</td><td>Does not analyze or correct any acoustic property — the signal returned is unmodified, just late.</td></tr>
           <tr><td>Pitch correction / "autotune"</td><td>Detects fundamental frequency and snaps it toward the nearest note in a scale.</td><td>Does not touch formant structure — vowel clarity is unaffected either way.</td></tr>
           <tr><td>Synthetic speech / voice cloning</td><td>Generates an entirely new audio signal from a model of a target voice, typically from text or a different reference recording.</td><td>Does not preserve the speaker's own real-time vocal tract output at all — the "voice" is model-generated, not the speaker's own corrected signal.</td></tr>
@@ -393,7 +395,7 @@
       </p>
       <p>
         <strong>The privacy reason.</strong> Because the entire pipeline — capture, analysis,
-        correction, resynthesis, playback — runs inside the browser's local audio processing
+        correction filtering, playback — runs inside the browser's local audio processing
         thread on the user's own device, there is no point in the signal chain where raw voice
         audio needs to be transmitted anywhere. This isn't a privacy policy layered on top of
         a system that could technically upload audio; it's a consequence of an architecture


### PR DESCRIPTION
## Summary

Asked to check whether the demo's performance actually matches the site's claims, and whether there's room to improve it. Both turned out to be real findings, not just copy issues.

**The correction algorithm itself was slower to lock onto a new target than the copy implied.** I fed real audio through the actual, unmodified worklet and independently tracked how long it takes the *output's measured formants* to reach a newly-set target — not just how fast the DSP math runs. Baseline: ~90–210ms to lock on, because a single fixed exponential-smoothing rate (`AL=0.88`) treated a genuine phoneme transition the same as ordinary frame-to-frame measurement noise.

- `demo.html`: added fast-attack/slow-release smoothing — a faster coefficient only kicks in when the freshly measured formant is far enough from the tracked estimate to be a real transition, not noise. Cuts mean convergence time roughly in half (**~171ms → ~84ms** across 10 trials) with no measurable increase in steady-state jitter. Re-verified against the *actual edited* worklet afterward: exact passthrough when inactive, F0 preserved exactly, formants still shift the correct direction, sub-millisecond audio pass-through latency unchanged.

**Separately, the site's own claims didn't match the real architecture.** `demo.html`, `science.html`, and `index.html` all described a single "<50ms" figure and a "resynthesis" pipeline stage that don't exist in the shipped code. The real bottleneck was never audio pass-through (genuinely ~1–3ms — correction is a direct sample-by-sample filter, not a buffer-and-regenerate step); it's the analysis needing a few frames to lock onto a *new* target after a phoneme changes (~50–150ms). Rewrote the latency budget table, timeline pin, and pipeline-stage copy on both pages to state both numbers honestly — including the realistic worst case where formant-lock time stacked with slower Bluetooth hardware can approach the 250ms hard cutoff, instead of implying it's always comfortably solved.

## Test plan
- [x] Re-extracted the edited worklet from `demo.html` and re-ran the correctness suite: exact no-op passthrough when inactive, F0 preserved exactly, formants move the correct direction toward target
- [x] Re-ran the convergence benchmark against the actual edited file (not just a prototype): 10 trials, mean 84ms vs 171ms baseline
- [x] Real end-to-end latency check in headless Chromium with real synthesized audio via `--use-file-for-fake-audio-capture`, tapping both the raw mic and corrected output live: pass-through lag unchanged at <1ms
- [x] Loaded `demo.html`, `science.html`, and `index.html` in a real browser after all edits: no console/page errors, Hear-It toggle still works


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Clarify how the correction pipeline actually operates and improve formant-lock convergence so stated latency claims better match real behavior.

Bug Fixes:
- Reduce formant-lock time after phoneme changes by introducing adaptive fast-attack/slow-release smoothing in the demo worklet.

Enhancements:
- Update latency copy and visual timeline to distinguish low audio pass-through delay from slower formant-lock convergence and reflect realistic end-to-end behavior.
- Reword pipeline and technology descriptions to describe correction as a direct real-time filter instead of a resynthesis step, aligning the site with the shipped architecture.

Documentation:
- Revise science, demo, and index pages to present accurate latency budgets, formant-lock ranges, and Bluetooth impact, including best- and worst-case scenarios and the role of LPC in the correction pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified real-time voice processing and latency explanations across the demo, research, and science pages.
  * Updated descriptions to explain direct filtering rather than waveform resynthesis, while preserving pitch, voicing, and timing.
  * Added details on approximately 100 ms delivery, Bluetooth latency, formant lock-on timing, and the 250 ms processing limit.
  * Documented smoother formant tracking with faster response when significant changes are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->