### PR TITLE
Fix Hear-It audio clipping/garbling — measured 22.6% of output samples clipping, now 0%

### DIFF
--- a/goeckoh-site/demo.html
+++ b/goeckoh-site/demo.html
@@ -1376,7 +1376,7 @@ let vowelHistory = [];
 /* ── Hear-It state ─────────────────────────────────────────── */
 let workletNode = null, hearItActive = false, hearItTimer = null, hearItRemaining = 0;
 let hearItModuleLoaded = false; // registerProcessor() may only run once per AudioContext
-let hearItGainNode = null, hearItLimiterNode = null;
+let hearItGainNode = null, hearItLimiterNode = null, hearItCompressorNode = null;
 // Mic capture below deliberately disables autoGainControl (see getUserMedia call) so the
 // browser's AGC doesn't pump/distort the signal the formant analysis depends on — but that
 // also means the raw signal reaching here is much quieter than any normal call/recording
@@ -1678,11 +1678,28 @@ async function toggleHearIt() {
     hearItLimiterNode = audioCtx.createWaveShaper();
     hearItLimiterNode.curve = HEARIT_SOFTCLIP_CURVE;
     hearItLimiterNode.oversample = '2x';
+    // The waveshaper's own oversampling (needed to keep the soft-clip curve from
+    // aliasing) overshoots its nominal ±1 bound by design — that's expected DSP
+    // behavior, not a bug, but it means the shaper alone doesn't guarantee a hard
+    // ceiling. For any mic input that isn't unusually quiet, HEARIT_OUTPUT_GAIN's
+    // fixed 3.5x (plus the shaper's own ~1.66x low-level boost) pushes the signal
+    // past full scale on a large fraction of samples — measured at ~23% of samples
+    // clipped, true peaks over 1.05, on a moderately-loud (not maxed) test signal.
+    // A real limiter after the shaper enforces the ceiling regardless of how loud
+    // the source mic actually is, instead of relying on one fixed gain constant
+    // being right for every device.
+    hearItCompressorNode = audioCtx.createDynamicsCompressor();
+    hearItCompressorNode.threshold.value = -3;
+    hearItCompressorNode.knee.value = 0;
+    hearItCompressorNode.ratio.value = 20;
+    hearItCompressorNode.attack.value = 0.001;
+    hearItCompressorNode.release.value = 0.05;
 
     micSourceNode.connect(workletNode);
     workletNode.connect(hearItGainNode);
     hearItGainNode.connect(hearItLimiterNode);
-    hearItLimiterNode.connect(audioCtx.destination);
+    hearItLimiterNode.connect(hearItCompressorNode);
+    hearItCompressorNode.connect(audioCtx.destination);
     pushHearItParams();
 
     hearItActive = true;
@@ -1745,6 +1762,7 @@ function stopHearIt() {
   if (workletNode)       { try { workletNode.disconnect(); }       catch (e) {} workletNode = null; }
   if (hearItGainNode)    { try { hearItGainNode.disconnect(); }    catch (e) {} hearItGainNode = null; }
   if (hearItLimiterNode) { try { hearItLimiterNode.disconnect(); } catch (e) {} hearItLimiterNode = null; }
+  if (hearItCompressorNode) { try { hearItCompressorNode.disconnect(); } catch (e) {} hearItCompressorNode = null; }
   hearItActive = false;
   hearItBtn.classList.remove('playing');
   hearItBtn.textContent = '🎧  Hear The Correction';


### PR DESCRIPTION
## **User description**
## Summary
Reported: audio in "Hear The Correction" comes through garbled/distorted, not clean.

Measured the actual output rather than guessing — fed a synthesized voice-like WAV in as the fake mic via Chromium's `--use-file-for-fake-audio-capture`, and tapped the true final output node with a sample-accurate recorder.

**Before:** 22.6% of output samples clipped (≥0.999 abs), true peaks reaching 1.055 — over full digital scale — for the entire test duration.

**Root cause:** `HEARIT_OUTPUT_GAIN` (3.5x fixed linear gain) plus the soft-clip WaveShaper's own low-level boost (~1.66x, ~5.8x combined) was tuned for a quiet-mic assumption, with no actual ceiling enforced afterward. The WaveShaper's 2x oversampling (needed to avoid aliasing the clip curve) overshoots its own nominal ±1 bound by design, so the shaper alone doesn't guarantee a hard limit — any mic input that isn't unusually quiet clips.

**Fix:** added a `DynamicsCompressorNode` configured as a fast brick-wall limiter (threshold -3dB, ratio 20:1, 1ms attack) after the existing gain+waveshaper chain, so output level is bounded by the actual signal rather than one fixed gain constant being correct for every device/mic.

**After:** 0% clipped samples, true peak 0.945 (was 1.055), no NaN/instability — on the identical test signal.

## Note
A separately reported "~5 seconds before anything is audible" symptom was **not** reproduced in this synthetic test (audio present from t=130ms). That's more consistent with device/mic-permission/hardware startup latency than a DSP bug in this file, and needs the real device's behavior to diagnose further — flagging it here rather than claiming it's fixed.

## Test plan
- [x] Headless Chromium, real fake-mic audio input (not silence, not full-scale)
- [x] Sample-accurate output capture (100ms RMS/peak windows + true peak + clip count) tapped at the actual final pre-destination node
- [x] Measured before: 22.6% clipped, peak 1.055
- [x] Measured after: 0% clipped, peak 0.945
- [x] Confirmed no NaN/instability introduced

https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Add a post-limiter stage to the Hear-It audio chain to prevent output clipping and distortion across varying input levels.

New Features:
- Introduce a DynamicsCompressor-based limiter after the Hear-It soft-clip waveshaper to enforce a hard output ceiling.

Bug Fixes:
- Eliminate audio clipping and garbling in Hear-It playback caused by excessive fixed gain into the soft-clip stage.

Enhancements:
- Update Hear-It node wiring and lifecycle management to include the new compressor node and ensure it is properly disconnected when playback stops.


___

## **CodeAnt-AI Description**
Prevent clipping and garbling in Hear The Correction audio

### What Changed
- Audio is now passed through a fast limiter before playback, keeping loud microphone input below full scale.
- The limiter is removed cleanly when Hear-It stops, so repeated start-and-stop sessions do not leave audio processing running in the background.
- Loud correction audio no longer produces the severe distortion caused by output levels exceeding the digital ceiling.

### Impact
`✅ Clearer Hear-It audio`
`✅ Fewer clipped audio samples`
`✅ Reliable cleanup across repeated sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Hear-It audio output control with smoother, more consistent volume levels.
  * Added automatic limiting to help prevent audio peaks and distortion.
  * Ensured audio processing is properly cleaned up when Hear-It stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->