### PR TITLE
Replace the "cyber futuristic" dark/neon theme with a clean, consistent light palette + fix runaway dashboard chart

### DIFF
--- a/goeckoh-site/advanced_voice_visualizer_pro.html
+++ b/goeckoh-site/advanced_voice_visualizer_pro.html
@@ -665,7 +665,7 @@
   <link rel="stylesheet" href="goeckoh-shared.css">
   <script src="gate.js"></script>
 </head>
-<body>
+<body class="light-theme">
   <nav class="gk-nav">
     <a href="index.html" class="gk-nav-brand">
       <img src="images/logo-light.png" alt="Goeckoh" class="gk-nav-logo">
@@ -688,8 +688,8 @@
   <header>
     <h1>🎤 Advanced Voice Visualizer Pro</h1>
     <div class="theme-controls">
-      <button class="theme-btn active" data-theme="dark">Dark</button>
-      <button class="theme-btn" data-theme="light">Light</button>
+      <button class="theme-btn" data-theme="dark">Dark</button>
+      <button class="theme-btn active" data-theme="light">Light</button>
       <button class="theme-btn" data-theme="colorblind">Accessible</button>
       <button class="icon-btn" onclick="showHelp()">❓ Help</button>
     </div>

--- a/goeckoh-site/goeckoh-shared.css
+++ b/goeckoh-site/goeckoh-shared.css
@@ -5,35 +5,40 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Fira+Code:wght@400;500&display=swap');
 
 :root {
-  /* Surfaces */
-  --gk-bg:        #05080f;
-  --gk-bg-card:   #0a1020;
-  --gk-bg-raised: #0f1830;
-  --gk-bg-input:  #131e34;
+  /* Surfaces — clean, neutral, light. This used to be a near-black "cyber"
+     palette that every tool page inherited by default unless it happened
+     to define its own local override (as index.html/demo.html/science.html
+     did). Making the light palette the actual shared default instead of a
+     per-page opt-in is what makes the product consistent instead of some
+     pages being clean and others neon-on-black by accident. */
+  --gk-bg:        #F7F5F0;
+  --gk-bg-card:   #FFFFFF;
+  --gk-bg-raised: #EDF1F7;
+  --gk-bg-input:  #EEF0F5;
 
   /* Brand — calm blue + soft teal. No neon. */
-  --gk-primary: #4d7cfe;
-  --gk-teal:    #14c591;
-  --gk-amber:   #f0a828;
-  --gk-red:     #f05060;
+  --gk-primary: #2558D9;
+  --gk-teal:    #2A8C7A;
+  --gk-amber:   #C97C1A;
+  --gk-red:     #C94040;
 
   /* Backward-compat aliases used in tool pages */
-  --gk-green:  #14c591;
-  --gk-blue:   #4d7cfe;
-  --gk-violet: #a78bfa;
+  --gk-green:  #2A8C7A;
+  --gk-blue:   #2558D9;
+  --gk-violet: #6B5FD8;
 
   /* Text */
-  --gk-text:   #eef2ff;
-  --gk-text-2: #8b9ec0;
-  --gk-muted:  #48597a;
+  --gk-text:   #1A2F4B;
+  --gk-text-2: #4B6280;
+  --gk-muted:  #8098B5;
 
   /* Borders */
-  --gk-border:   rgba(255,255,255,0.07);
-  --gk-border-2: rgba(255,255,255,0.13);
+  --gk-border:   rgba(26,47,75,0.10);
+  --gk-border-2: rgba(26,47,75,0.17);
 
   /* Shadow */
-  --gk-shadow:    0 12px 40px rgba(0,0,0,0.55);
-  --gk-shadow-sm: 0 2px 10px rgba(0,0,0,0.35);
+  --gk-shadow:    0 8px 30px rgba(0,0,0,0.08);
+  --gk-shadow-sm: 0 2px 8px rgba(0,0,0,0.05);
 
   /* Shape */
   --gk-radius:    14px;
@@ -51,7 +56,7 @@
   top: 0; left: 0; right: 0;
   height: var(--gk-nav-h);
   z-index: 9999;
-  background: rgba(5,8,15,0.94);
+  background: rgba(247,245,240,0.94);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border-bottom: 1px solid var(--gk-border);
@@ -112,11 +117,11 @@
   transition: color 0.15s, background 0.15s;
   white-space: nowrap;
 }
-.gk-nav-link:hover  { color: var(--gk-text); background: rgba(255,255,255,0.05); }
-.gk-nav-link.active { color: var(--gk-teal); background: rgba(20,197,145,0.08); }
+.gk-nav-link:hover  { color: var(--gk-text); background: rgba(26,47,75,0.05); }
+.gk-nav-link.active { color: var(--gk-teal); background: rgba(42,140,122,0.1); }
 
 .gk-nav-cta {
-  color: #05080f !important;
+  color: #fff !important;
   background: var(--gk-primary) !important;
   font-family: var(--gk-font);
   font-size: 0.8rem;
@@ -193,11 +198,11 @@
   line-height: 1;
 }
 .gk-btn-primary  { background: var(--gk-primary); color: #fff; }
-.gk-btn-primary:hover  { opacity: 0.88; transform: translateY(-1px); box-shadow: 0 6px 24px rgba(77,124,254,0.35); }
-.gk-btn-teal     { background: var(--gk-teal); color: #05080f; }
+.gk-btn-primary:hover  { opacity: 0.88; transform: translateY(-1px); box-shadow: 0 6px 24px rgba(37,88,217,0.35); }
+.gk-btn-teal     { background: var(--gk-teal); color: #fff; }
 .gk-btn-teal:hover     { opacity: 0.88; transform: translateY(-1px); }
 .gk-btn-secondary { background: transparent; color: var(--gk-text); border: 1px solid var(--gk-border-2); }
-.gk-btn-secondary:hover { background: rgba(255,255,255,0.05); }
+.gk-btn-secondary:hover { background: rgba(26,47,75,0.05); }
 .gk-btn-sm { padding: 0.48rem 1rem; font-size: 0.8rem; }
 
 /* ── Badges ─────────────────────────────────────────────────────── */

--- a/goeckoh-site/goeckoh_dashboard.html
+++ b/goeckoh-site/goeckoh_dashboard.html
@@ -232,7 +232,9 @@
                 <!-- F1/F2 formant scatter (last 200 utterances) -->
                 <div class="glass-panel p-3">
                     <div style="font-size:0.6rem;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:#64748b;margin-bottom:0.5rem">Vowel Space (last 200 utterances)</div>
-                    <canvas id="formantScatter" width="600" height="200" style="width:100%;height:160px"></canvas>
+                    <div style="position:relative;height:220px">
+                        <canvas id="formantScatter"></canvas>
+                    </div>
                 </div>
                 <div id="statsNote" style="font-size:0.68rem;color:#94a3b8;margin-top:0.4rem;text-align:right">
                     Historical data refreshes every 30 s · requires backend connection

--- a/goeckoh-site/real_time_therapeutic_voice_cloning_system.html
+++ b/goeckoh-site/real_time_therapeutic_voice_cloning_system.html
@@ -9,18 +9,24 @@
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Fira+Code:wght@400;500&display=swap');
         
         :root {
-            --bg-dark: #0a0e1a;
-            --bg-card: #131829;
-            --bg-elevated: #1a2033;
-            --accent-primary: #00ff9d;
-            --accent-secondary: #00c3ff;
-            --accent-warning: #ffaa00;
-            --accent-error: #ff4466;
-            --text-primary: #ffffff;
-            --text-secondary: #a0aec0;
-            --text-muted: #718096;
-            --border: rgba(255, 255, 255, 0.1);
-            --shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+            /* Clean, neutral light palette — was a near-black "cyber" theme
+               with neon green/cyan/amber accents, inconsistent with the
+               rest of the product and inappropriate for a tool used by
+               children with sensory sensitivities. Variable names kept
+               identical so every var(--...) reference below picks up the
+               new values automatically. */
+            --bg-dark: #F7F5F0;
+            --bg-card: #FFFFFF;
+            --bg-elevated: #EDF1F7;
+            --accent-primary: #2A8C7A;
+            --accent-secondary: #2558D9;
+            --accent-warning: #C97C1A;
+            --accent-error: #C94040;
+            --text-primary: #1A2F4B;
+            --text-secondary: #4B6280;
+            --text-muted: #8098B5;
+            --border: rgba(26, 47, 75, 0.10);
+            --shadow: 0 10px 40px rgba(0, 0, 0, 0.08);
         }
         
         * {
@@ -31,7 +37,7 @@
         
         body {
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-            background: linear-gradient(135deg, var(--bg-dark) 0%, #0f1420 100%);
+            background: linear-gradient(135deg, var(--bg-dark) 0%, #F0EDE8 100%);
             color: var(--text-primary);
             min-height: 100vh;
             overflow-x: hidden;
@@ -230,7 +236,7 @@
         }
         
         .btn-danger {
-            background: linear-gradient(135deg, #ff4466, #ff6b88);
+            background: linear-gradient(135deg, #C94040, #E07A5F);
             color: white;
         }
         
@@ -596,8 +602,8 @@
                 </div>
                 <div style="font-size:0.68rem;color:var(--text-secondary);line-height:1.55">
                     <span style="font-size:1rem">💻</span><br>
-                    <strong style="color:var(--text-primary);color:#00c3ff">Guardian monitors separately</strong><br>
-                    A caregiver or therapist can watch your session from their own device via the <a href="goeckoh_dashboard.html" style="color:#00c3ff;text-decoration:none">Dashboard</a>.
+                    <strong style="color:var(--text-primary);color:#2558D9">Guardian monitors separately</strong><br>
+                    A caregiver or therapist can watch your session from their own device via the <a href="goeckoh_dashboard.html" style="color:#2558D9;text-decoration:none">Dashboard</a>.
                 </div>
             </div>
         </div>
@@ -622,10 +628,10 @@
             </div>
             <div class="status-info" id="guardianCodeBar" style="display:none">
                 <div class="status-item">
-                    <span class="status-label">Guardian Code: <strong id="guardianCodeText" style="color:#00c3ff;letter-spacing:0.15em;font-size:1.05em">------</strong></span>
+                    <span class="status-label">Guardian Code: <strong id="guardianCodeText" style="color:#2558D9;letter-spacing:0.15em;font-size:1.05em">------</strong></span>
                 </div>
                 <div class="status-item" style="font-size:0.75rem;color:var(--text-secondary)">
-                    Share with caregiver → <a href="goeckoh_dashboard.html" style="color:#00c3ff;text-decoration:none">Dashboard</a>
+                    Share with caregiver → <a href="goeckoh_dashboard.html" style="color:#2558D9;text-decoration:none">Dashboard</a>
                 </div>
             </div>
         </div>
@@ -1643,7 +1649,7 @@ const PROFILES = {
                     this.canvasCtx.fillStyle = 'rgba(10,14,26,0.3)';
                     this.canvasCtx.fillRect(0, 0, W, H);
                     this.canvasCtx.lineWidth   = 2;
-                    this.canvasCtx.strokeStyle = '#00ff9d';
+                    this.canvasCtx.strokeStyle = '#2A8C7A';
                     this.canvasCtx.beginPath();
 
                     const sw = W / this.dispLen;
@@ -1660,7 +1666,7 @@ const PROFILES = {
                         const sr = this.audioContext.sampleRate;
                         this.canvasCtx.globalAlpha  = 0.45;
                         this.canvasCtx.lineWidth    = 1;
-                        [[this.liveF1,'#00c3ff'],[this.liveF2,'#ffaa00']].forEach(([f, col]) => {
+                        [[this.liveF1,'#2558D9'],[this.liveF2,'#C97C1A']].forEach(([f, col]) => {
                             const xf = (f / (sr/2)) * W;
                             this.canvasCtx.strokeStyle = col;
                             this.canvasCtx.beginPath();


### PR DESCRIPTION
## **User description**
## Summary
The tool suite (Echo Therapy, Visualizer, Profile Lab, Setup) rendered in a near-black background with neon green/cyan/amber/red accents — visually inconsistent with the rest of the product and inappropriate for a tool used by children with sensory sensitivities.

**Root cause:** `goeckoh-shared.css`'s own `:root` defined the dark/neon palette as the actual default for every page that includes it. `index.html`/`demo.html`/`science.html` only looked clean because each defined its own local light-theme override on top. Any tool page without that override (`voice_setup.html`, `voice_therapy_profile_transform.html`) inherited the dark "cyber" look by accident.

## What changed
- **`goeckoh-shared.css`**: made the light palette (matching `index.html`'s already-established look) the actual shared default. Fixed a few hardcoded dark-specific values (`.gk-nav` background, button text contrast, hover overlay tints) that would've looked wrong against the new light surfaces. This alone fixes `voice_setup.html` and `voice_therapy_profile_transform.html`, since both already correctly reference `var(--gk-*)` with no local override.
- **`real_time_therapeutic_voice_cloning_system.html`** (main Echo Therapy tool): has its own separate `:root` with different variable names — updated directly to the same light palette, plus every hardcoded neon hex found via grep.
- **`advanced_voice_visualizer_pro.html`**: already had a working Dark/Light/Accessible toggle with real light-theme CSS, just defaulted to Dark. Switched the default.
- **`goeckoh_dashboard.html`**: fixed a real bug while in there — the vowel-space Chart.js scatter plot grew without bound and broke the page layout (canvas HTML attributes + inline CSS height fighting each other with no bounded-height parent for Chart.js's responsive resizing). Wrapped it in a div with explicit height.

`voice_game.html` left as-is — a full-screen bubble-catching game reasonably supports a more vibrant look, and wasn't reported as visually broken.

## Test plan
- [x] Verified all four pages visually with Playwright screenshots (localStorage-seeded access to bypass the download-gate redirect)
- [x] Confirmed nav, buttons, cards all consistent and light across pages
- [x] Confirmed dashboard chart no longer grows unbounded

https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFCHbefWLZ55vdra4ANdKC)_

## Summary by Sourcery

Switch the shared site styling and key tool pages from a dark, neon “cyber” theme to a unified light palette and fix a layout bug in the dashboard vowel-space chart.

Bug Fixes:
- Constrain the dashboard vowel-space Chart.js scatter plot within a fixed-height container so it no longer grows unbounded.

Enhancements:
- Make the light visual palette the default in shared CSS so all tools inherit a clean, consistent look.
- Update the Echo Therapy page’s local theme variables and hardcoded colors to align with the new light brand palette.
- Change Advanced Voice Visualizer Pro to default to the existing light theme instead of dark.


___

## **CodeAnt-AI Description**
Switch tool pages to a calm light theme and stabilize the dashboard chart

### What Changed
- Tool pages now open with a consistent warm light palette instead of a dark neon appearance.
- Echo Therapy uses calmer colors across its interface, waveform, frequency markers, buttons, alerts, and guardian links.
- The Voice Visualizer opens in Light mode by default while retaining Dark and Accessible options.
- The dashboard’s vowel-space chart now stays within a fixed-height area instead of expanding and disrupting the page layout.

### Impact
`✅ Calmer tool screens for children with sensory sensitivities`
`✅ Consistent light appearance across the tool suite`
`✅ Stable dashboard chart layout`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the site’s visual design with a light theme, neutral backgrounds, and blue/teal branding.
  * Set the light theme as the default, with theme controls reflecting the active selection.
  * Improved button, navigation, status, waveform, and chart styling for clearer contrast.
  * Made the formant scatter chart responsive across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->